### PR TITLE
test: refactored crawler unittests (#14)

### DIFF
--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -33,362 +33,370 @@ PROJECT_NAME = "test-gcp-scanner"
 
 
 def print_diff(f1, f2):
-    with open(f1, "r", encoding="utf-8") as file_1:
-        file_1_text = file_1.readlines()
+  with open(f1, "r", encoding="utf-8") as file_1:
+    file_1_text = file_1.readlines()
 
-    with open(f2, "r", encoding="utf-8") as file_2:
-        file_2_text = file_2.readlines()
+  with open(f2, "r", encoding="utf-8") as file_2:
+    file_2_text = file_2.readlines()
 
-    # Find and print the diff:
-    res = ""
-    for line in difflib.unified_diff(file_1_text, file_2_text, fromfile=f1,
-                                     tofile=f2, lineterm=""):
-        print(line)
-        res += line
+  # Find and print the diff:
+  res = ""
+  for line in difflib.unified_diff(file_1_text, file_2_text, fromfile=f1,
+                                   tofile=f2, lineterm=""):
+    print(line)
+    res += line
 
 
 def save_to_test_file(res):
-    res = json.dumps(res, indent=2, sort_keys=False)
-    with open("test_res", "w", encoding="utf-8") as outfile:
-        outfile.write(res)
+  res = json.dumps(res, indent=2, sort_keys=False)
+  with open("test_res", "w", encoding="utf-8") as outfile:
+    outfile.write(res)
 
 
 def compare_volatile(f1, f2):
-    res = True
-    with open(f1, "r", encoding="utf-8") as file_1:
-        file_1_text = file_1.readlines()
+  res = True
+  with open(f1, "r", encoding="utf-8") as file_1:
+    file_1_text = file_1.readlines()
 
-    with open(f2, "r", encoding="utf-8") as file_2:
-        file_2_text = file_2.readlines()
+  with open(f2, "r", encoding="utf-8") as file_2:
+    file_2_text = file_2.readlines()
 
-    for line in file_2_text:
-        # line = line[:-1]
-        if line.startswith("VOLATILE"):
-            continue  # we do not compare volatile lines
-        if line in file_1_text:
-            continue
-        else:
-            print(f"The following line was not identified in the output:\n{line}")
-            res = False
+  for line in file_2_text:
+    # line = line[:-1]
+    if line.startswith("VOLATILE"):
+      continue  # we do not compare volatile lines
+    if line in file_1_text:
+      continue
+    else:
+      print(f"The following line was not identified in the output:\n{line}")
+      res = False
 
-    return res
+  return res
 
 
 def verify(res_to_verify, resource_type, volatile=False):
-    save_to_test_file(res_to_verify)
-    f1 = "test_res"
-    f2 = f"test/{resource_type}"
+  save_to_test_file(res_to_verify)
+  f1 = "test_res"
+  f2 = f"test/{resource_type}"
 
-    if volatile is True:
-        result = compare_volatile(f1, f2)
-    else:
-        result = filecmp.cmp(f1, f2)
-        if result is False:
-            print_diff(f1, f2)
+  if volatile is True:
+    result = compare_volatile(f1, f2)
+  else:
+    result = filecmp.cmp(f1, f2)
+    if result is False:
+      print_diff(f1, f2)
 
-    return result
+  return result
 
 
 def test_creds_fetching():
-    os.mkdir("creds")
-    conn = sqlite3.connect("creds/credentials.db")
-    c = conn.cursor()
-    c.execute("""
+  os.mkdir("creds")
+  conn = sqlite3.connect("creds/credentials.db")
+  c = conn.cursor()
+  c.execute("""
            CREATE TABLE credentials (account_id TEXT PRIMARY KEY, value BLOB)
             """)
-    sqlite_insert_with_param = """INSERT INTO "credentials"
+  sqlite_insert_with_param = """INSERT INTO "credentials"
                                 ("account_id", "value")
                                 VALUES (?, ?);"""
 
-    data_value = ("test_account@gmail.com", "test_data")
-    c.execute(sqlite_insert_with_param, data_value)
-    conn.commit()
+  data_value = ("test_account@gmail.com", "test_data")
+  c.execute(sqlite_insert_with_param, data_value)
+  conn.commit()
 
-    assert str(credsdb.find_creds("./creds")) == "['./creds/credentials.db']"
+  assert str(credsdb.find_creds("./creds")) == "['./creds/credentials.db']"
 
-    conn = sqlite3.connect("creds/access_tokens.db")
-    c = conn.cursor()
-    c.execute("""
+  conn = sqlite3.connect("creds/access_tokens.db")
+  c = conn.cursor()
+  c.execute("""
             CREATE TABLE IF NOT EXISTS access_tokens
             (account_id TEXT PRIMARY KEY,
              access_token TEXT, token_expiry TIMESTAMP, 
              rapt_token TEXT, id_token TEXT)
             """)
 
-    valid_tm = datetime.datetime.now() + datetime.timedelta(hours=2, minutes=10)
-    expired_tm = datetime.datetime.now() - datetime.timedelta(hours=2, minutes=10)
-    sqlite_insert_with_param = """INSERT INTO "access_tokens"
+  valid_tm = datetime.datetime.now() + datetime.timedelta(hours=2, minutes=10)
+  expired_tm = datetime.datetime.now() - datetime.timedelta(hours=2, minutes=10)
+  sqlite_insert_with_param = """INSERT INTO "access_tokens"
                                 ("account_id", "access_token",
                                  "token_expiry", "rapt_token", "id_token")
                                 VALUES (?, ?, ?, ?, ?);"""
 
-    data_value = ("test_account@gmail.com", "ya.29c.TEST",
-                  valid_tm, "test", "test2")
-    c.execute(sqlite_insert_with_param, data_value)
-    data_value = ("test_account2@gmail.com", "ya.29c.TEST",
-                  expired_tm, "test", "test2")
-    c.execute(sqlite_insert_with_param, data_value)
-    conn.commit()
+  data_value = ("test_account@gmail.com", "ya.29c.TEST",
+                valid_tm, "test", "test2")
+  c.execute(sqlite_insert_with_param, data_value)
+  data_value = ("test_account2@gmail.com", "ya.29c.TEST",
+                expired_tm, "test", "test2")
+  c.execute(sqlite_insert_with_param, data_value)
+  conn.commit()
 
-    assert str(credsdb.get_access_tokens_dict("./creds/credentials.db")) == \
-           "{'test_account@gmail.com': 'ya.29c.TEST'}"
+  assert str(credsdb.get_access_tokens_dict("./creds/credentials.db")) == \
+         "{'test_account@gmail.com': 'ya.29c.TEST'}"
 
-    res = str(credsdb.extract_creds("./creds/credentials.db"))
-    print(res)
-    assert res == "[SA(account_name='test_account@gmail.com', \
+  res = str(credsdb.extract_creds("./creds/credentials.db"))
+  print(res)
+  assert res == "[SA(account_name='test_account@gmail.com', \
 creds='test_data', token='ya.29c.TEST')]"
 
-    assert str(credsdb.get_account_creds_list("./creds")) == \
-           "[[SA(account_name='test_account@gmail.com', \
-       creds='test_data', token='ya.29c.TEST')]]"
+  assert str(credsdb.get_account_creds_list("./creds")) == \
+         "[[SA(account_name='test_account@gmail.com', \
+     creds='test_data', token='ya.29c.TEST')]]"
 
-    # impersonate_sa()
-    shutil.rmtree("creds")
+  # impersonate_sa()
+  shutil.rmtree("creds")
 
 
 class TestCrawler(unittest.TestCase):
-    """Test crawler functionalities."""
+  """Test crawler functionalities."""
 
-    def setUp(self):
-        _, self.credentials = credsdb.get_creds_from_metadata()
-        self.compute_client = scanner.compute_client_for_credentials(self.credentials)
+  def setUp(self):
+    _, self.credentials = credsdb.get_creds_from_metadata()
+    self.compute_client = scanner.compute_client_for_credentials(
+      self.credentials,
+    )
 
-    def test_credential(self):
-        """Checks if credential is not none."""
-        self.assertIsNotNone(self.credentials)
+  def test_credential(self):
+    """Checks if credential is not none."""
+    self.assertIsNotNone(self.credentials)
 
-    def test_compute_instance_name(self):
-        """Test compute instance name."""
-        self.assertTrue(
-            verify(
-                crawl.get_compute_instances_names(PROJECT_NAME, self.compute_client),
-                "compute_instances",
-                True,
-            )
-        )
+  def test_compute_instance_name(self):
+    """Test compute instance name."""
+    self.assertTrue(
+      verify(
+        crawl.get_compute_instances_names(PROJECT_NAME, self.compute_client),
+        "compute_instances",
+        True,
+      )
+    )
 
-    def test_compute_disks_names(self):
-        """Test compute disk names."""
-        self.assertTrue(
-            verify(
-                crawl.get_compute_disks_names(PROJECT_NAME, self.compute_client),
-                "compute_disks",
-                True,
-            )
-        )
+  def test_compute_disks_names(self):
+    """Test compute disk names."""
+    self.assertTrue(
+      verify(
+        crawl.get_compute_disks_names(PROJECT_NAME, self.compute_client),
+        "compute_disks",
+        True,
+      )
+    )
 
-    def test_compute_images_names(self):
-        """Test compute image names."""
-        self.assertTrue(
-            verify(
-                crawl.get_compute_images_names(PROJECT_NAME, self.compute_client),
-                "compute_images",
-                True,
-            )
-        )
+  def test_compute_images_names(self):
+    """Test compute image names."""
+    self.assertTrue(
+      verify(
+        crawl.get_compute_images_names(PROJECT_NAME, self.compute_client),
+        "compute_images",
+        True,
+      )
+    )
 
-    def test_static_ips(self):
-        """Test static IPs."""
-        self.assertTrue(
-            verify(
-                crawl.get_static_ips(PROJECT_NAME, self.compute_client),
-                "static_ips",
-                True,
-            )
-        )
+  def test_static_ips(self):
+    """Test static IPs."""
+    self.assertTrue(
+      verify(
+        crawl.get_static_ips(PROJECT_NAME, self.compute_client),
+        "static_ips",
+        True,
+      )
+    )
 
-    def test_compute_snapshots(self):
-        """Test compute snapshot."""
-        self.assertTrue(
-            verify(
-                crawl.get_compute_snapshots(PROJECT_NAME, self.compute_client),
-                "compute_snapshots",
-                True,
-            )
-        )
+  def test_compute_snapshots(self):
+    """Test compute snapshot."""
+    self.assertTrue(
+      verify(
+        crawl.get_compute_snapshots(PROJECT_NAME, self.compute_client),
+        "compute_snapshots",
+        True,
+      )
+    )
 
-    def test_firewall_rules(self):
-        """Test firewall rules."""
-        self.assertTrue(
-            verify(
-                crawl.get_firewall_rules(PROJECT_NAME, self.compute_client),
-                "firewall_rules",
-            )
-        )
+  def test_firewall_rules(self):
+    """Test firewall rules."""
+    self.assertTrue(
+      verify(
+        crawl.get_firewall_rules(PROJECT_NAME, self.compute_client),
+        "firewall_rules",
+      )
+    )
 
-    def test_subnets(self):
-        """Test subnets."""
-        self.assertTrue(
-            verify(
-                crawl.get_subnets(PROJECT_NAME, self.compute_client),
-                "subnets",
-                True,
-            )
-        )
+  def test_subnets(self):
+    """Test subnets."""
+    self.assertTrue(
+      verify(
+        crawl.get_subnets(PROJECT_NAME, self.compute_client),
+        "subnets",
+        True,
+      )
+    )
 
-    def test_storage_buckets(self):
-        """Test storage bucket."""
-        self.assertTrue(
-            verify(
-                crawl.get_bucket_names(PROJECT_NAME, credentials=self.credentials, dump_fd=None),
-                "storage_buckets",
-            )
-        )
+  def test_storage_buckets(self):
+    """Test storage bucket."""
+    self.assertTrue(
+      verify(
+        crawl.get_bucket_names(
+          PROJECT_NAME,
+          credentials=self.credentials,
+          dump_fd=None,
+        ),
+        "storage_buckets",
+      )
+    )
 
-    def test_managed_zones(self):
-        """Test managed zones."""
-        self.assertTrue(
-            verify(
-                crawl.get_managed_zones(PROJECT_NAME, credentials=self.credentials),
-                "managed_zones",
-                True,
-            )
-        )
+  def test_managed_zones(self):
+    """Test managed zones."""
+    self.assertTrue(
+      verify(
+        crawl.get_managed_zones(PROJECT_NAME, credentials=self.credentials),
+        "managed_zones",
+        True,
+      )
+    )
 
-    def test_gke_clusters(self):
-        """Test GKE clusters."""
-        gke_client = scanner.gke_client_for_credentials(credentials=self.credentials)
-        self.assertTrue(
-            verify(
-                crawl.get_gke_clusters(PROJECT_NAME, gke_client),
-                "gke_clusters",
-            )
-        )
+  def test_gke_clusters(self):
+    """Test GKE clusters."""
+    gke_client = scanner.gke_client_for_credentials(
+      credentials=self.credentials,
+    )
+    self.assertTrue(
+      verify(
+        crawl.get_gke_clusters(PROJECT_NAME, gke_client),
+        "gke_clusters",
+      )
+    )
 
-    def test_gke_images(self):
-        self.assertTrue(
-            verify(
-                crawl.get_gke_images(PROJECT_NAME, self.credentials.token),
-                "gke_images",
-                True,
-            )
-        )
+  def test_gke_images(self):
+    self.assertTrue(
+      verify(
+        crawl.get_gke_images(PROJECT_NAME, self.credentials.token),
+        "gke_images",
+        True,
+      )
+    )
 
-    def test_app_services(self):
-        """Test app services."""
-        self.assertTrue(
-            verify(
-                crawl.get_app_services(PROJECT_NAME, self.credentials),
-                "app_services",
-            )
-        )
+  def test_app_services(self):
+    """Test app services."""
+    self.assertTrue(
+      verify(
+        crawl.get_app_services(PROJECT_NAME, self.credentials),
+        "app_services",
+      )
+    )
 
-    def test_sql_instances(self):
-        """Test SQL instances."""
-        self.assertTrue(
-            verify(
-                crawl.get_sql_instances(PROJECT_NAME, self.credentials),
-                "sql_instances",
-                True,
-            )
-        )
+  def test_sql_instances(self):
+    """Test SQL instances."""
+    self.assertTrue(
+      verify(
+        crawl.get_sql_instances(PROJECT_NAME, self.credentials),
+        "sql_instances",
+        True,
+      )
+    )
 
-    def test_bq(self):
-        """Test BigQuery databases and table names."""
-        self.assertTrue(
-            verify(
-                crawl.get_bq(PROJECT_NAME, self.credentials),
-                "bq",
-            )
-        )
+  def test_bq(self):
+    """Test BigQuery databases and table names."""
+    self.assertTrue(
+      verify(
+        crawl.get_bq(PROJECT_NAME, self.credentials),
+        "bq",
+      )
+    )
 
-    def test_pubsub_subs(self):
-        """Test PubSub Subscriptions."""
-        self.assertTrue(
-            verify(
-                crawl.get_pubsub_subscriptions(PROJECT_NAME, self.credentials),
-                "pubsub_subs",
-            )
-        )
+  def test_pubsub_subs(self):
+    """Test PubSub Subscriptions."""
+    self.assertTrue(
+      verify(
+        crawl.get_pubsub_subscriptions(PROJECT_NAME, self.credentials),
+        "pubsub_subs",
+      )
+    )
 
-    def test_cloud_functions(self):
-        """Test CloudFunctions list."""
-        self.assertTrue(
-            verify(
-                crawl.get_cloudfunctions(PROJECT_NAME, self.credentials),
-                "cloud_functions",
-            )
-        )
+  def test_cloud_functions(self):
+    """Test CloudFunctions list."""
+    self.assertTrue(
+      verify(
+        crawl.get_cloudfunctions(PROJECT_NAME, self.credentials),
+        "cloud_functions",
+      )
+    )
 
-    def test_bigtable_instances(self):
-        """Test BigTable Instances."""
-        self.assertTrue(
-            verify(
-                crawl.get_bigtable_instances(PROJECT_NAME, self.credentials),
-                "bigtable_instances",
-            )
-        )
+  def test_bigtable_instances(self):
+    """Test BigTable Instances."""
+    self.assertTrue(
+      verify(
+        crawl.get_bigtable_instances(PROJECT_NAME, self.credentials),
+        "bigtable_instances",
+      )
+    )
 
-    def test_spanner_instances(self):
-        """Test Spanner Instances."""
-        self.assertTrue(
-            verify(
-                crawl.get_spanner_instances(PROJECT_NAME, self.credentials),
-                "spanner_instances",
-            )
-        )
+  def test_spanner_instances(self):
+    """Test Spanner Instances."""
+    self.assertTrue(
+      verify(
+        crawl.get_spanner_instances(PROJECT_NAME, self.credentials),
+        "spanner_instances",
+      )
+    )
 
-    def test_cloudstore_instances(self):
-        """Test CloudStore Instances."""
-        self.assertTrue(
-            verify(
-                crawl.get_filestore_instances(PROJECT_NAME, self.credentials),
-                "cloudstore_instances",
-            )
-        )
+  def test_cloudstore_instances(self):
+    """Test CloudStore Instances."""
+    self.assertTrue(
+      verify(
+        crawl.get_filestore_instances(PROJECT_NAME, self.credentials),
+        "cloudstore_instances",
+      )
+    )
 
-    def test_kms(self):
-        """Test list of KMS keys."""
-        self.assertTrue(
-            verify(
-                crawl.get_kms_keys(PROJECT_NAME, self.credentials),
-                "kms",
-                True,
-            )
-        )
+  def test_kms(self):
+    """Test list of KMS keys."""
+    self.assertTrue(
+      verify(
+        crawl.get_kms_keys(PROJECT_NAME, self.credentials),
+        "kms",
+        True,
+      )
+    )
 
-    def test_endpoints(self):
-        """Test endpoints' information."""
-        self.assertTrue(
-            verify(
-                crawl.get_endpoints(PROJECT_NAME, self.credentials),
-                "endpoints",
-            )
-        )
+  def test_endpoints(self):
+    """Test endpoints' information."""
+    self.assertTrue(
+      verify(
+        crawl.get_endpoints(PROJECT_NAME, self.credentials),
+        "endpoints",
+      )
+    )
 
-    def test_services(self):
-        """Test list of API services enabled in the project."""
-        self.assertTrue(
-            verify(
-                crawl.list_services(PROJECT_NAME, self.credentials),
-                "services",
-                True
-            )
-        )
+  def test_services(self):
+    """Test list of API services enabled in the project."""
+    self.assertTrue(
+      verify(
+        crawl.list_services(PROJECT_NAME, self.credentials),
+        "services",
+        True
+      )
+    )
 
-    def test_iam_policy(self):
-        """Test IAM policy."""
-        self.assertTrue(
-            verify(
-                crawl.get_iam_policy(PROJECT_NAME, self.credentials),
-                "iam_policy",
-            )
-        )
+  def test_iam_policy(self):
+    """Test IAM policy."""
+    self.assertTrue(
+      verify(
+        crawl.get_iam_policy(PROJECT_NAME, self.credentials),
+        "iam_policy",
+      )
+    )
 
-    def test_service_accounts(self):
-        """Test service accounts."""
-        self.assertTrue(
-            verify(
-                crawl.get_service_accounts(PROJECT_NAME, self.credentials),
-                "service_accounts",
-            )
-        )
+  def test_service_accounts(self):
+    """Test service accounts."""
+    self.assertTrue(
+      verify(
+        crawl.get_service_accounts(PROJECT_NAME, self.credentials),
+        "service_accounts",
+      )
+    )
 
-    def test_project_info(self):
-        """Test project info."""
-        self.assertTrue(
-            verify(
-                crawl.fetch_project_info(PROJECT_NAME, self.credentials),
-                "project_info",
-            )
-        )
+  def test_project_info(self):
+    """Test project info."""
+    self.assertTrue(
+      verify(
+        crawl.fetch_project_info(PROJECT_NAME, self.credentials),
+        "project_info",
+      )
+    )

--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -16,225 +16,379 @@
 
 """
 
-from . import crawl
-from . import credsdb
-import json
-from . import scanner
-import filecmp
+import datetime
 import difflib
+import filecmp
+import json
 import os
 import shutil
 import sqlite3
-import datetime
+import unittest
+
+from . import crawl
+from . import credsdb
+from . import scanner
 
 PROJECT_NAME = "test-gcp-scanner"
 
 
 def print_diff(f1, f2):
-  with open(f1, "r", encoding="utf-8") as file_1:
-    file_1_text = file_1.readlines()
+    with open(f1, "r", encoding="utf-8") as file_1:
+        file_1_text = file_1.readlines()
 
-  with open(f2, "r", encoding="utf-8") as file_2:
-    file_2_text = file_2.readlines()
+    with open(f2, "r", encoding="utf-8") as file_2:
+        file_2_text = file_2.readlines()
 
-  # Find and print the diff:
-  res = ""
-  for line in difflib.unified_diff(file_1_text, file_2_text, fromfile=f1,
-                                   tofile=f2, lineterm=""):
-    print(line)
-    res += line
+    # Find and print the diff:
+    res = ""
+    for line in difflib.unified_diff(file_1_text, file_2_text, fromfile=f1,
+                                     tofile=f2, lineterm=""):
+        print(line)
+        res += line
+
 
 def save_to_test_file(res):
-  res = json.dumps(res, indent=2, sort_keys=False)
-  with open("test_res", "w", encoding="utf-8") as outfile:
-    outfile.write(res)
+    res = json.dumps(res, indent=2, sort_keys=False)
+    with open("test_res", "w", encoding="utf-8") as outfile:
+        outfile.write(res)
+
 
 def compare_volatile(f1, f2):
-  res = True
-  with open(f1, "r", encoding="utf-8") as file_1:
-    file_1_text = file_1.readlines()
+    res = True
+    with open(f1, "r", encoding="utf-8") as file_1:
+        file_1_text = file_1.readlines()
 
-  with open(f2, "r", encoding="utf-8") as file_2:
-    file_2_text = file_2.readlines()
+    with open(f2, "r", encoding="utf-8") as file_2:
+        file_2_text = file_2.readlines()
 
-  for line in file_2_text:
-    #line = line[:-1]
-    if line.startswith("VOLATILE"):
-      continue # we do not compare volatile lines
-    if line in file_1_text:
-      continue
-    else:
-      print(f"The following line was not identified in the output:\n{line}")
-      res = False
+    for line in file_2_text:
+        # line = line[:-1]
+        if line.startswith("VOLATILE"):
+            continue  # we do not compare volatile lines
+        if line in file_1_text:
+            continue
+        else:
+            print(f"The following line was not identified in the output:\n{line}")
+            res = False
 
-  return res
+    return res
+
 
 def verify(res_to_verify, resource_type, volatile=False):
-  save_to_test_file(res_to_verify)
-  f1 = "test_res"
-  f2 = f"test/{resource_type}"
+    save_to_test_file(res_to_verify)
+    f1 = "test_res"
+    f2 = f"test/{resource_type}"
 
-  if volatile is True:
-    result = compare_volatile(f1, f2)
-  else:
-    result = filecmp.cmp(f1, f2)
-    if result is False:
-      print_diff(f1, f2)
+    if volatile is True:
+        result = compare_volatile(f1, f2)
+    else:
+        result = filecmp.cmp(f1, f2)
+        if result is False:
+            print_diff(f1, f2)
 
-  return result
+    return result
 
 
 def test_creds_fetching():
-  os.mkdir("creds")
-  conn = sqlite3.connect("creds/credentials.db")
-  c = conn.cursor()
-  c.execute("""
+    os.mkdir("creds")
+    conn = sqlite3.connect("creds/credentials.db")
+    c = conn.cursor()
+    c.execute("""
            CREATE TABLE credentials (account_id TEXT PRIMARY KEY, value BLOB)
             """)
-  sqlite_insert_with_param = """INSERT INTO "credentials"
+    sqlite_insert_with_param = """INSERT INTO "credentials"
                                 ("account_id", "value")
                                 VALUES (?, ?);"""
 
-  data_value = ("test_account@gmail.com", "test_data")
-  c.execute(sqlite_insert_with_param, data_value)
-  conn.commit()
+    data_value = ("test_account@gmail.com", "test_data")
+    c.execute(sqlite_insert_with_param, data_value)
+    conn.commit()
 
-  assert str(credsdb.find_creds("./creds")) == "['./creds/credentials.db']"
+    assert str(credsdb.find_creds("./creds")) == "['./creds/credentials.db']"
 
-  conn = sqlite3.connect("creds/access_tokens.db")
-  c = conn.cursor()
-  c.execute("""
+    conn = sqlite3.connect("creds/access_tokens.db")
+    c = conn.cursor()
+    c.execute("""
             CREATE TABLE IF NOT EXISTS access_tokens
             (account_id TEXT PRIMARY KEY,
              access_token TEXT, token_expiry TIMESTAMP, 
              rapt_token TEXT, id_token TEXT)
             """)
 
-  valid_tm = datetime.datetime.now() + datetime.timedelta(hours=2, minutes=10)
-  expired_tm = datetime.datetime.now() - datetime.timedelta(hours=2, minutes=10)
-  sqlite_insert_with_param = """INSERT INTO "access_tokens"
+    valid_tm = datetime.datetime.now() + datetime.timedelta(hours=2, minutes=10)
+    expired_tm = datetime.datetime.now() - datetime.timedelta(hours=2, minutes=10)
+    sqlite_insert_with_param = """INSERT INTO "access_tokens"
                                 ("account_id", "access_token",
                                  "token_expiry", "rapt_token", "id_token")
                                 VALUES (?, ?, ?, ?, ?);"""
 
-  data_value = ("test_account@gmail.com", "ya.29c.TEST",
-                valid_tm, "test", "test2")
-  c.execute(sqlite_insert_with_param, data_value)
-  data_value = ("test_account2@gmail.com", "ya.29c.TEST",
-                expired_tm, "test", "test2")
-  c.execute(sqlite_insert_with_param, data_value)
-  conn.commit()
+    data_value = ("test_account@gmail.com", "ya.29c.TEST",
+                  valid_tm, "test", "test2")
+    c.execute(sqlite_insert_with_param, data_value)
+    data_value = ("test_account2@gmail.com", "ya.29c.TEST",
+                  expired_tm, "test", "test2")
+    c.execute(sqlite_insert_with_param, data_value)
+    conn.commit()
 
-  assert str(credsdb.get_access_tokens_dict("./creds/credentials.db")) == \
-    "{'test_account@gmail.com': 'ya.29c.TEST'}"
+    assert str(credsdb.get_access_tokens_dict("./creds/credentials.db")) == \
+           "{'test_account@gmail.com': 'ya.29c.TEST'}"
 
-  res = str(credsdb.extract_creds("./creds/credentials.db"))
-  print(res)
-  assert res == "[SA(account_name='test_account@gmail.com', \
+    res = str(credsdb.extract_creds("./creds/credentials.db"))
+    print(res)
+    assert res == "[SA(account_name='test_account@gmail.com', \
 creds='test_data', token='ya.29c.TEST')]"
 
-  assert str(credsdb.get_account_creds_list("./creds")) == \
-    "[[SA(account_name='test_account@gmail.com', \
-creds='test_data', token='ya.29c.TEST')]]"
+    assert str(credsdb.get_account_creds_list("./creds")) == \
+           "[[SA(account_name='test_account@gmail.com', \
+       creds='test_data', token='ya.29c.TEST')]]"
 
-  #impersonate_sa()
-  shutil.rmtree("creds")
+    # impersonate_sa()
+    shutil.rmtree("creds")
 
 
-def test_crawler():
-  _, credentials = credsdb.get_creds_from_metadata()
-  assert credentials is not None
+class TestCrawler(unittest.TestCase):
+    """Test crawler functionalities."""
 
-  # GCE section
-  compute_client = scanner.compute_client_for_credentials(credentials)
-  assert verify(crawl.get_compute_instances_names(PROJECT_NAME, compute_client),
-                                                  "compute_instances",
-                                                  True) is True
-  assert verify(crawl.get_compute_disks_names(PROJECT_NAME, compute_client),
-                                             "compute_disks",
-                                             True) is True
-  assert verify(crawl.get_compute_images_names(PROJECT_NAME, compute_client),
-                                             "compute_images") is True
-  assert verify(crawl.get_static_ips(PROJECT_NAME, compute_client),
-                                     "static_ips") is True
-  assert verify(crawl.get_compute_snapshots(PROJECT_NAME, compute_client),
-                                            "compute_snapshots",
-                                            True) is True
-  assert verify(crawl.get_firewall_rules(PROJECT_NAME, compute_client),
-                                         "firewall_rules") is True
-  assert verify(crawl.get_subnets(PROJECT_NAME, compute_client),
-                                  "subnets",
-                                  True) is True
+    def setUp(self):
+        _, self.credentials = credsdb.get_creds_from_metadata()
+        self.compute_client = scanner.compute_client_for_credentials(self.credentials)
 
-  assert verify(crawl.get_bucket_names(PROJECT_NAME, credentials=credentials,
-                                       dump_fd = None),
-                                      "storage_buckets") is True
+    def test_credential(self):
+        """Checks if credential is not none."""
+        self.assertIsNotNone(self.credentials)
 
-  assert verify(crawl.get_managed_zones(PROJECT_NAME, credentials=credentials),
-                                        "managed_zones",
-                                        True) is True
+    def test_compute_instance_name(self):
+        """Test compute instance name."""
+        self.assertTrue(
+            verify(
+                crawl.get_compute_instances_names(PROJECT_NAME, self.compute_client),
+                "compute_instances",
+                True,
+            )
+        )
 
-  gke_client = scanner.gke_client_for_credentials(credentials=credentials)
-  assert verify(crawl.get_gke_clusters(PROJECT_NAME, gke_client),
-                                       "gke_clusters") is True
+    def test_compute_disks_names(self):
+        """Test compute disk names."""
+        self.assertTrue(
+            verify(
+                crawl.get_compute_disks_names(PROJECT_NAME, self.compute_client),
+                "compute_disks",
+                True,
+            )
+        )
 
-  assert verify(crawl.get_gke_images(PROJECT_NAME, credentials.token),
-                                     "gke_images",
-                                     True) is True
+    def test_compute_images_names(self):
+        """Test compute image names."""
+        self.assertTrue(
+            verify(
+                crawl.get_compute_images_names(PROJECT_NAME, self.compute_client),
+                "compute_images",
+                True,
+            )
+        )
 
-  assert verify(crawl.get_app_services(PROJECT_NAME, credentials),
-                                       "app_services") is True
+    def test_static_ips(self):
+        """Test static IPs."""
+        self.assertTrue(
+            verify(
+                crawl.get_static_ips(PROJECT_NAME, self.compute_client),
+                "static_ips",
+                True,
+            )
+        )
 
-  # Get SQL instances
-  assert verify(crawl.get_sql_instances(PROJECT_NAME, credentials),
-                                        "sql_instances",
-                                        True) is True
+    def test_compute_snapshots(self):
+        """Test compute snapshot."""
+        self.assertTrue(
+            verify(
+                crawl.get_compute_snapshots(PROJECT_NAME, self.compute_client),
+                "compute_snapshots",
+                True,
+            )
+        )
 
-  # Get BigQuery databases and table names
-  assert verify(crawl.get_bq(PROJECT_NAME, credentials), "bq") is True
+    def test_firewall_rules(self):
+        """Test firewall rules."""
+        self.assertTrue(
+            verify(
+                crawl.get_firewall_rules(PROJECT_NAME, self.compute_client),
+                "firewall_rules",
+            )
+        )
 
-  # Get PubSub Subscriptions
-  assert verify(crawl.get_pubsub_subscriptions(
-          PROJECT_NAME, credentials), "pubsub_subs") is True
+    def test_subnets(self):
+        """Test subnets."""
+        self.assertTrue(
+            verify(
+                crawl.get_subnets(PROJECT_NAME, self.compute_client),
+                "subnets",
+                True,
+            )
+        )
 
-  # Get CloudFunctions list
-  assert verify(crawl.get_cloudfunctions(
-          PROJECT_NAME, credentials), "cloud_functions") is True
+    def test_storage_buckets(self):
+        """Test storage bucket."""
+        self.assertTrue(
+            verify(
+                crawl.get_bucket_names(PROJECT_NAME, credentials=self.credentials, dump_fd=None),
+                "storage_buckets",
+            )
+        )
 
-  # Get List of BigTable Instanses
-  assert verify(crawl.get_bigtable_instances(
-          PROJECT_NAME, credentials), "bigtable_instances") is True
+    def test_managed_zones(self):
+        """Test managed zones."""
+        self.assertTrue(
+            verify(
+                crawl.get_managed_zones(PROJECT_NAME, credentials=self.credentials),
+                "managed_zones",
+                True,
+            )
+        )
 
-  # Get Spanner Instances
-  assert verify(crawl.get_spanner_instances(
-          PROJECT_NAME, credentials), "spanner_instances") is True
+    def test_gke_clusters(self):
+        """Test GKE clusters."""
+        gke_client = scanner.gke_client_for_credentials(credentials=self.credentials)
+        self.assertTrue(
+            verify(
+                crawl.get_gke_clusters(PROJECT_NAME, gke_client),
+                "gke_clusters",
+            )
+        )
 
-  # Get CloudStore Instances
-  assert verify(crawl.get_filestore_instances(
-          PROJECT_NAME, credentials), "cloudstore_instances") is True
+    def test_gke_images(self):
+        self.assertTrue(
+            verify(
+                crawl.get_gke_images(PROJECT_NAME, self.credentials.token),
+                "gke_images",
+                True,
+            )
+        )
 
-  # Get list of KMS keys
-  assert verify(crawl.get_kms_keys(PROJECT_NAME, credentials),
-                                   "kms",
-                                   True) is True
+    def test_app_services(self):
+        """Test app services."""
+        self.assertTrue(
+            verify(
+                crawl.get_app_services(PROJECT_NAME, self.credentials),
+                "app_services",
+            )
+        )
 
-  # Get information about Endpoints
-  assert verify(crawl.get_endpoints(PROJECT_NAME, credentials),
-                                    "endpoints") is True
+    def test_sql_instances(self):
+        """Test SQL instances."""
+        self.assertTrue(
+            verify(
+                crawl.get_sql_instances(PROJECT_NAME, self.credentials),
+                "sql_instances",
+                True,
+            )
+        )
 
-  # Get list of API services enabled in the project
-  assert verify(crawl.list_services(PROJECT_NAME, credentials),
-                                    "services",
-                                    True) is True
+    def test_bq(self):
+        """Test BigQuery databases and table names."""
+        self.assertTrue(
+            verify(
+                crawl.get_bq(PROJECT_NAME, self.credentials),
+                "bq",
+            )
+        )
 
-  # IAM Policy
-  assert verify(crawl.get_iam_policy(PROJECT_NAME, credentials),
-                                     "iam_policy") is True
+    def test_pubsub_subs(self):
+        """Test PubSub Subscriptions."""
+        self.assertTrue(
+            verify(
+                crawl.get_pubsub_subscriptions(PROJECT_NAME, self.credentials),
+                "pubsub_subs",
+            )
+        )
 
-  # Get service accounts
-  assert verify(crawl.get_service_accounts(PROJECT_NAME, credentials),
-                                           "service_accounts") is True
+    def test_cloud_functions(self):
+        """Test CloudFunctions list."""
+        self.assertTrue(
+            verify(
+                crawl.get_cloudfunctions(PROJECT_NAME, self.credentials),
+                "cloud_functions",
+            )
+        )
 
-  # Get project info
-  assert verify(crawl.fetch_project_info(PROJECT_NAME, credentials),
-                                         "project_info") is True
+    def test_bigtable_instances(self):
+        """Test BigTable Instances."""
+        self.assertTrue(
+            verify(
+                crawl.get_bigtable_instances(PROJECT_NAME, self.credentials),
+                "bigtable_instances",
+            )
+        )
+
+    def test_spanner_instances(self):
+        """Test Spanner Instances."""
+        self.assertTrue(
+            verify(
+                crawl.get_spanner_instances(PROJECT_NAME, self.credentials),
+                "spanner_instances",
+            )
+        )
+
+    def test_cloudstore_instances(self):
+        """Test CloudStore Instances."""
+        self.assertTrue(
+            verify(
+                crawl.get_filestore_instances(PROJECT_NAME, self.credentials),
+                "cloudstore_instances",
+            )
+        )
+
+    def test_kms(self):
+        """Test list of KMS keys."""
+        self.assertTrue(
+            verify(
+                crawl.get_kms_keys(PROJECT_NAME, self.credentials),
+                "kms",
+                True,
+            )
+        )
+
+    def test_endpoints(self):
+        """Test endpoints' information."""
+        self.assertTrue(
+            verify(
+                crawl.get_endpoints(PROJECT_NAME, self.credentials),
+                "endpoints",
+            )
+        )
+
+    def test_services(self):
+        """Test list of API services enabled in the project."""
+        self.assertTrue(
+            verify(
+                crawl.list_services(PROJECT_NAME, self.credentials),
+                "services",
+                True
+            )
+        )
+
+    def test_iam_policy(self):
+        """Test IAM policy."""
+        self.assertTrue(
+            verify(
+                crawl.get_iam_policy(PROJECT_NAME, self.credentials),
+                "iam_policy",
+            )
+        )
+
+    def test_service_accounts(self):
+        """Test service accounts."""
+        self.assertTrue(
+            verify(
+                crawl.get_service_accounts(PROJECT_NAME, self.credentials),
+                "service_accounts",
+            )
+        )
+
+    def test_project_info(self):
+        """Test project info."""
+        self.assertTrue(
+            verify(
+                crawl.fetch_project_info(PROJECT_NAME, self.credentials),
+                "project_info",
+            )
+        )


### PR DESCRIPTION
Fixes #14 
Related to #1 

- [x] Organized crawler tests inside class
- [x] Replaces `asserts` with `unittest.assertEqual`
- [x] Fixed indentation of the code 
- [x] Organized imports.