### PR TITLE
fix: wrong docstring for `get_gke_clusters` function

### DIFF
--- a/src/gcp_scanner/crawl.py
+++ b/src/gcp_scanner/crawl.py
@@ -420,7 +420,7 @@ def get_gke_clusters(
     project_name: str, gke_client: container_v1.services.cluster_manager.client
     .ClusterManagerClient
 ) -> List[Tuple[str, str]]:
-  """Retrieve a list of DNS zones available in the project.
+  """Retrieve a list of GKE clusters available in the project.
 
   Args:
     project_name: A name of a project to query info about.

--- a/src/gcp_scanner/crawl.py
+++ b/src/gcp_scanner/crawl.py
@@ -1001,7 +1001,7 @@ def list_services(project_id: str, credentials: Credentials) -> List[Any]:
       request = serviceusage.services().list_next(
           previous_request=request, previous_response=response)
   except Exception:
-    logging.info("Failed to retrive services for project %s", project_id)
+    logging.info("Failed to retrieve services for project %s", project_id)
     logging.info(sys.exc_info())
 
   return list_of_services


### PR DESCRIPTION
Fixes #44

- [x] Updated docstring for `get_gke_clusters` method
- [x] Spelling error fixed in a logger.