### PR TITLE
feat: OAuth2 credentials with no scopes for refresh token

### DIFF
--- a/src/gcp_scanner/credsdb.py
+++ b/src/gcp_scanner/credsdb.py
@@ -378,7 +378,7 @@ def creds_from_refresh_token(refresh_token_file):
   with open(refresh_token_file, encoding="utf-8") as f:
     creds_dict = json.load(f)
 
-  user_scopes = get_scope_from_refresh_token(creds_dict)
+  user_scopes = get_scopes_from_refresh_token(creds_dict)
 
   return credentials.Credentials(
     None,
@@ -390,8 +390,8 @@ def creds_from_refresh_token(refresh_token_file):
   )
 
 
-def get_scope_from_refresh_token(context) -> Union[List[str], None]:
-  """The function is used to obtain scope from refresh token.
+def get_scopes_from_refresh_token(context) -> Union[List[str], None]:
+  """The function is used to obtain scopes from refresh token.
 
   Args:
     context: dictionary containing refresh_token data

--- a/src/gcp_scanner/credsdb.py
+++ b/src/gcp_scanner/credsdb.py
@@ -411,5 +411,5 @@ def get_scope_from_refresh_token(context) -> Union[List[str], None]:
 
   # prepare the scope string into a list
   raw = response.json().get("scope", None)
-  return raw.split(' ') if raw else None
+  return raw.split(" ") if raw else None
 

--- a/src/gcp_scanner/credsdb.py
+++ b/src/gcp_scanner/credsdb.py
@@ -402,14 +402,24 @@ def get_scopes_from_refresh_token(context) -> Union[List[str], None]:
         "client_secret": "secret",
       }
   Returns:
-    a list of scopes
+    a list of scopes or None
   """
   # Obtain access token from the refresh token
   token_uri = "https://oauth2.googleapis.com/token"
   context["grant_type"] = "refresh_token"
-  response = requests.post(token_uri, data=context)
 
-  # prepare the scope string into a list
-  raw = response.json().get("scope", None)
-  return raw.split(" ") if raw else None
+  try:
+    response = requests.post(token_uri, data=context, timeout=5)
+    # prepare the scope string into a list
+    raw = response.json().get("scope", None)
+    return raw.split(" ") if raw else None
+  except Exception as ex:
+    logging.error(
+      "Failed to retrieve access token from refresh token.",
+    )
+    logging.debug("Token refresh exception", exc_info=ex)
+
+  return None
+
+
 

--- a/src/gcp_scanner/credsdb.py
+++ b/src/gcp_scanner/credsdb.py
@@ -380,8 +380,6 @@ def creds_from_refresh_token(refresh_token_file):
     creds_dict = json.load(f)
 
   user_scopes = creds_dict.get("scopes", None)
-  if user_scopes is None:
-    user_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
   return credentials.Credentials(
       None,

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -69,6 +69,8 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
     # Log the chain we used to get here (even if we have no privs)
     sa_results['service_account_chain'] = chain_so_far
     sa_results['current_service_account'] = sa_name
+    # Add token scopes in the result
+    sa_results["token_scopes"] = credentials.scopes
 
     project_list = crawl.get_project_list(credentials)
     if len(project_list) <= 0:

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -70,7 +70,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
     sa_results['service_account_chain'] = chain_so_far
     sa_results['current_service_account'] = sa_name
     # Add token scopes in the result
-    sa_results["token_scopes"] = credentials.scopes
+    sa_results['token_scopes'] = credentials.scopes
 
     project_list = crawl.get_project_list(credentials)
     if len(project_list) <= 0:


### PR DESCRIPTION
Fixes #21 

As I investigated, As of now, I found that `refresh_tokens` are bounded with scopes already.  So I think we don't need to enforce `cloud-platform` scope for `refresh_token`. However, we can use a refresh token to retrieve the access token with the scope list.
This solution uses the refresh token to retrieve the list of scopes.

- [x] Implemented a refresh mechanism to obtain an access token. 
- [x] The access token is returned with the original list of scopes.
- [x] Unit test for `get_scopes_from_refresh_token`
- [x] Dump `token_scopes` in the `sa_result`

I implemented some unit tests by mocking the API response.
As far as I read about unit testing. I think we should not depend on the test_project for unit tests. We can call those gcp-dependent tests **"Integration Test"**
I am not perfectly sure though as I don't have expert-level experience in these. Looking for your opinion here