### PR TITLE
feat: Enable Versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+# GitHub release for GCP versioning
+name: release
+
+# the release workflow is triggered by each push with new tag
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          # upload all files
+          file: ./*
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+
+### Test Usage ###
+# First finish git commit
+# $ git tag [tagname] -m '[comment]'
+# e.g. $ git tag v1.0.0 -m 'test for versioning'
+# git push origin v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,27 @@
 # GitHub release for GCP versioning
 name: release
 
-# the release workflow is triggered by each push with new tag
+# The release workflow is triggered by each push with new tag
 on:
   push:
     tags:
       - '*'
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Creat a release and upload assets.
+      # Note that the release automatically contains source code, the upload assets can be a description file of this version, e.g. change.txt
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        run: |
+          gh release create ${{ github.ref }} ./*.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload asset
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          # upload all files
-          file: ./*
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true
 
 ### Test Usage ###
 # First finish git commit


### PR DESCRIPTION
## Description
Enable versioning for GCP Scanner with GitHub release and tag.

## Changes Made
Add a YAML file to modify GitHub Action workflow.

## Usage 
Step 1: commit
Step 2: assign a tag. 
`git tag v1.0.0 -m 'test for versioning'`
Step 3: push.
 `git push origin v1.0.0`
Result: a release and a tag are automatically generated.

## Related Issues
#20 
related pr: #35 

## Additional Notes
This function requires configuring the workflow permissions with 'Read and Write permissions'.