### PR TITLE
docs: updated README.md with python-client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Option `-f` requires an additional explanation. In some cases, the service accou
 
 ### Building a standalone binary with PyInstaller
 
-Please replace `google-api-python-client==2.9.0` with `google-api-python-client==1.8.0` in `pyproject.toml`. After that, navigate to the scanner source code directory and use pyinstaller to compile a standalone binary:
+Please replace `google-api-python-client==2.80.0` with `google-api-python-client==1.8.0` in `pyproject.toml`. After that, navigate to the scanner source code directory and use pyinstaller to compile a standalone binary:
 
 `pyinstaller -F --add-data 'roots.pem:grpc/_cython/_credentials/' scanner.py`
 


### PR DESCRIPTION
docs: updated README.md with python-client version


## Description

To documentation be beginner friendly and to avoid confusion, I have made some contribution on README.md

## Changes Made
As in the current README.md file its mentioned that, replace "google-api-python-client==2.9.0 with google-api-python-client==1.8.0 in pyproject.toml". But, in the ./pyproject.toml file it has given that version of google-api-python-client is 2.80.0 initially. So, I have just changed the version.

## Checklist
- [ x ] I have read and followed the contributing guidelines.
- [ x ] I have tested my changes thoroughly and they work as expected.
- [ x ] I have added necessary tests for the changes made.
- [ x ] I have updated the documentation to reflect the changes made.
- [ x ] My code follows the project's coding style and standards.
- [ x ] I have added appropriate commit messages and comments for my changes.


## Related Issues
[If your changes relate to any existing issues, please list them here.]

## Additional Notes
[Provide any additional notes or context that may be helpful for the reviewers.]

Feel free to modify and customize this template as needed to fit the specific needs of the GCP Scanner project.