### PR TITLE
fix: Add timestamp to filename while saving output of gcp scan

### DIFF
--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import sys
+from pathlib import Path
 from datetime import datetime
 from typing import List, Tuple, Dict, Optional,Union
 
@@ -272,16 +273,18 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Generate current timestamp to append to output filename
       scan_time_suffix = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+      output_file_name = f'{project_id}-{scan_time_suffix}.json'
+      output_path = Path(out_dir, output_file_name)
       
-      # Generate the output filename and append the timestamp (to make filename unique for every scan)
-      output_file_name = f'{out_dir}/{project_id}-{scan_time_suffix}.json'
-      
-      with open(output_file_name, 'a',
-                encoding='utf-8') as outfile:
-        outfile.write(sa_results_data)
+      try:
+          with open(output_path, 'x',
+                    encoding='utf-8') as outfile:
+              outfile.write(sa_results_data)
 
-      # Clean memory to avoid leak for large amount projects.
-      sa_results.clear()
+              # Clean memory to avoid leak for large amount projects.
+              sa_results.clear()
+      except FileExistsError:
+          logging.error('Output file already exists. Try rescanning after removing the existing file.')
 
 
 def iam_client_for_credentials(

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -277,14 +277,14 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
       output_path = Path(out_dir, output_file_name)
       
       try:
-          with open(output_path, 'x',
-                    encoding='utf-8') as outfile:
-              outfile.write(sa_results_data)
+        with open(output_path, 'x', encoding='utf-8') as outfile:
+          outfile.write(sa_results_data)
 
-              # Clean memory to avoid leak for large amount projects.
-              sa_results.clear()
+        # Clean memory to avoid leak for large amount projects.
+        sa_results.clear()
       except FileExistsError:
-          logging.error('Output file already exists. Try rescanning after removing the existing file.')
+        logging.error('Output file already exists. Try rescanning \
+          after removing the existing file.')
 
 
 def iam_client_for_credentials(

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -270,7 +270,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       sa_results_data = json.dumps(sa_results, indent=2, sort_keys=False)
 
-      scan_time_suffix = datetime.now().strftime("%d-%m-%Y-%H:%M:%S")
+      scan_time_suffix = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
       with open(out_dir + '/%s-' % project_id + scan_time_suffix + '.json', 'a',
                 encoding='utf-8') as outfile:
         outfile.write(sa_results_data)

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -55,6 +55,9 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
     force_projects: a list of projects to force scan
   """
 
+  # Generate current timestamp to append to the filename
+  scan_time_suffix = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+
   context = SpiderContext(initial_sa_tuples)
   # Main loop
   processed_sas = set()
@@ -88,9 +91,6 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
           project_list.append({'projectId': force_project_id,
                                'projectNumber': 'N/A'})
 
-    # Generate current timestamp to append to output filename
-    scan_time_suffix = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-
     # Enumerate projects accessible by SA
     for project in project_list:
       if target_project and target_project not in project['projectId']:
@@ -112,8 +112,8 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
           pass
 
       except FileExistsError:
-        logging.error(f'Output file {output_file_name} already exists. \
-Try rescanning after removing the existing file.')
+        logging.error('Try removing the %s file and restart the scanner.',
+                      output_file_name)
 
       if is_set(scan_config, 'iam_policy'):
         # Get IAM policy

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import sys
+from datetime import datetime
 from typing import List, Tuple, Dict, Optional,Union
 
 from . import crawl
@@ -269,7 +270,8 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       sa_results_data = json.dumps(sa_results, indent=2, sort_keys=False)
 
-      with open(out_dir + '/%s.json' % project_id, 'a',
+      scan_time_suffix = datetime.now().strftime("%d-%m-%Y-%H:%M:%S")
+      with open(out_dir + '/%s-' % project_id + scan_time_suffix + '.json', 'a',
                 encoding='utf-8') as outfile:
         outfile.write(sa_results_data)
 

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -270,8 +270,13 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       sa_results_data = json.dumps(sa_results, indent=2, sort_keys=False)
 
+      # Generate current timestamp to append to output filename
       scan_time_suffix = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-      with open(f'{out_dir}/{project_id}-{scan_time_suffix}.json', 'a',
+      
+      # Generate the output filename and append the timestamp (to make filename unique for every scan)
+      output_file_name = f'{out_dir}/{project_id}-{scan_time_suffix}.json'
+      
+      with open(output_file_name, 'a',
                 encoding='utf-8') as outfile:
         outfile.write(sa_results_data)
 

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -270,8 +270,8 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       sa_results_data = json.dumps(sa_results, indent=2, sort_keys=False)
 
-      scan_time_suffix = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-      with open(out_dir + '/%s-' % project_id + scan_time_suffix + '.json', 'a',
+      scan_time_suffix = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+      with open(f'{out_dir}/{project_id}-{scan_time_suffix}.json', 'a',
                 encoding='utf-8') as outfile:
         outfile.write(sa_results_data)
 


### PR DESCRIPTION
This PR fixes https://github.com/google/gcp_scanner/issues/79.
This PR is continuation of #84.

Reason of Bug
The current src/gcp_scanner/scanner.py file in the codebase, creates a JSON file with the name of the project to store the output of the scan. If the file already exists, it opens the same file in the append mode and appends the output of the scan to the same file.

Approach to fix the bug
I added the timestamp of the scan to the name of the output file while writing the scan results. In this way, for every scan, there will be different output files where the output would be written into.

Before the changes
The output gets appended to same file in case of multiple scans.
