### PR TITLE
feat: Enable lightweight scanning option

### DIFF
--- a/example_config
+++ b/example_config
@@ -81,7 +81,7 @@
   "service_accounts": {
     "fetch": true,
     "comment": "Fetch list of available service accounts",
-    "impersonate": true
+    "impersonate": false
   },
   "dns_policies": {
     "fetch": true

--- a/src/gcp_scanner/arguments.py
+++ b/src/gcp_scanner/arguments.py
@@ -43,7 +43,13 @@ def arg_parser():
       dest='output',
       default='scan_db',
       help='Path to output directory')
-
+  parser.add_argument(
+      '-ls',
+      '--light-scan',
+      default=False,
+      dest='light_scan',
+      action='store_true',
+      help='Return only the most important GCP resource fields in the output.')
   parser.add_argument(
       '-k',
       '--sa-key-path',

--- a/src/gcp_scanner/credsdb.py
+++ b/src/gcp_scanner/credsdb.py
@@ -95,21 +95,21 @@ service-accounts/default/scopes"
 service-accounts/default/email"
   headers = {"Metadata-Flavor": "Google"}
   try:
-    res = requests.get(token_url, headers=headers)
+    res = requests.get(token_url, headers=headers, timeout=120)
     if not res.ok:
       logging.error("Failed to retrieve instance token. Status code %d",
                     res.status_code)
       return None, None
     token = res.json()["access_token"]
 
-    res = requests.get(scope_url, headers=headers)
+    res = requests.get(scope_url, headers=headers, timeout=120)
     if not res.ok:
       logging.error("Failed to retrieve instance scopes. Status code %d",
                     res.status_code)
       return None, None
     instance_scopes = res.content.decode("utf-8")
 
-    res = requests.get(email_url, headers=headers)
+    res = requests.get(email_url, headers=headers, timeout=120)
     if not res.ok:
       logging.error("Failed to retrieve instance email. Status code %d",
                     res.status_code)

--- a/src/gcp_scanner/test_acceptance.py
+++ b/src/gcp_scanner/test_acceptance.py
@@ -46,7 +46,7 @@ PUBSUB_COUNT = 1
 CLOUD_FUNCTIONS = 1
 ENDPOINTS_COUNT = 0
 KMS_COUNT = 1
-SERVICES_COUNT = 1
+SERVICES_COUNT = 37
 SERVICE_ACCOUNTS_COUNT = 3
 
 def check_obj_entry(res_dict, subojects_count, entry_name, volatile = False):

--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -71,6 +71,7 @@ def compare_volatile(f1, f2):
     if not line.startswith("CHECK"):
       continue  # we compare only important part of output
     line = line.replace("CHECK", "")
+    line = line.strip()
     if line in file_1_text:
       continue
     else:

--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -61,7 +61,7 @@ def save_to_test_file(res):
 def compare_volatile(f1, f2):
   res = True
   with open(f1, "r", encoding="utf-8") as file_1:
-    file_1_text = file_1.readlines()
+    file_1_text = file_1.read()
 
   with open(f2, "r", encoding="utf-8") as file_2:
     file_2_text = file_2.readlines()
@@ -71,7 +71,6 @@ def compare_volatile(f1, f2):
       continue  # we compare only important part of output
     line = line.replace("CHECK", "")
     line = line.strip()
-    line = line[:-1]
     if line in file_1_text:
       continue
     else:

--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -71,6 +71,7 @@ def compare_volatile(f1, f2):
       continue  # we compare only important part of output
     line = line.replace("CHECK", "")
     line = line.strip()
+    line = line[:-1]
     if line in file_1_text:
       continue
     else:

--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -67,7 +67,6 @@ def compare_volatile(f1, f2):
     file_2_text = file_2.readlines()
 
   for line in file_2_text:
-    # line = line[:-1]
     if not line.startswith("CHECK"):
       continue  # we compare only important part of output
     line = line.replace("CHECK", "")
@@ -78,6 +77,8 @@ def compare_volatile(f1, f2):
       print(f"The following line was not identified in the output:\n{line}")
       res = False
 
+  if res is False:
+    print(file_1_text)
   return res
 
 

--- a/test/dns_policies
+++ b/test/dns_policies
@@ -1,29 +1,27 @@
 [
-  [
-    {
-      "id": "1199893578059967130",
-CHECK      "name": "test-policy",
-CHECK      "enableInboundForwarding": true,
-CHECK      "description": "A test policy",
-CHECK      "networks": [
+  {
+    "id": "1199893578059967130",
+CHECK    "name": "test-policy",
+CHECK    "enableInboundForwarding": true,
+CHECK    "description": "A test policy",
+CHECK    "networks": [
+      {
+CHECK        "networkUrl": "https://www.googleapis.com/compute/v1/projects/test-gcp-scanner/global/networks/test-vpc",
+CHECK        "kind": "dns#policyNetwork"
+      }
+    ],
+CHECK    "alternativeNameServerConfig": {
+CHECK      "targetNameServers": [
         {
-CHECK          "networkUrl": "https://www.googleapis.com/compute/v1/projects/test-gcp-scanner/global/networks/test-vpc",
-CHECK          "kind": "dns#policyNetwork"
+CHECK          "ipv4Address": "8.8.8.8",
+CHECK          "forwardingPath": "private",
+CHECK          "ipv6Address": "",
+CHECK          "kind": "dns#policyAlternativeNameServerConfigTargetNameServer"
         }
       ],
-CHECK      "alternativeNameServerConfig": {
-CHECK        "targetNameServers": [
-          {
-CHECK            "ipv4Address": "8.8.8.8",
-CHECK            "forwardingPath": "private",
-CHECK            "ipv6Address": "",
-CHECK            "kind": "dns#policyAlternativeNameServerConfigTargetNameServer"
-          }
-        ],
-CHECK        "kind": "dns#policyAlternativeNameServerConfig"
-      },
-      "enableLogging": false,
-CHECK      "kind": "dns#policy"
-    }
-  ]
+CHECK      "kind": "dns#policyAlternativeNameServerConfig"
+    },
+    "enableLogging": false,
+CHECK    "kind": "dns#policy"
+  }
 ]

--- a/test/services
+++ b/test/services
@@ -1,2440 +1,2438 @@
 [
-  [
-    {
-CHECK      "name": "projects/413204024550/services/appengine.googleapis.com",
-      "config": {
-        "name": "appengine.googleapis.com",
-        "title": "App Engine Admin API",
-        "documentation": {
-          "summary": "Provisions and manages developers' App Engine applications."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
-          {
-            "type": "serviceruntime.googleapis.com/api",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_version"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_method"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/consumer_project"
-              },
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/consumer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/producer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/consumer_resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
+  {
+CHECK    "name": "projects/413204024550/services/appengine.googleapis.com",
+    "config": {
+      "name": "appengine.googleapis.com",
+      "title": "App Engine Admin API",
+      "documentation": {
+        "summary": "Provisions and manages developers' App Engine applications."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "serviceruntime.googleapis.com/api",
+          "labels": [
             {
-              "monitoredResource": "serviceruntime.googleapis.com/api",
-              "metrics": [
-                "serviceruntime.googleapis.com/api/consumer/request_count",
-                "serviceruntime.googleapis.com/api/consumer/error_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_used_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
-                "serviceruntime.googleapis.com/api/consumer/total_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
-                "serviceruntime.googleapis.com/api/consumer/backend_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_sizes",
-                "serviceruntime.googleapis.com/api/consumer/response_sizes",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
-                "serviceruntime.googleapis.com/quota/used",
-                "serviceruntime.googleapis.com/quota/limit",
-                "serviceruntime.googleapis.com/quota/exceeded",
-                "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
-              ]
+              "key": "cloud.googleapis.com/location"
             },
             {
-              "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
-              "metrics": [
-                "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
-                "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
-                "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
-                "serviceruntime.googleapis.com/quota/consumer/limit",
-                "serviceruntime.googleapis.com/quota/consumer/exceeded"
-              ]
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_version"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_method"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/consumer_project"
+            },
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/consumer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/producer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/consumer_resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
             }
           ]
         }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/autoscaling.googleapis.com",
-      "config": {
-        "name": "autoscaling.googleapis.com",
-        "title": "Cloud Autoscaling API",
-        "documentation": {
-          "summary": "An API for the Cloud Autoscaling for consuming autoscaling signals.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-      "name": "projects/413204024550/services/bigquery.googleapis.com",
-      "config": {
-        "name": "bigquery.googleapis.com",
-        "title": "BigQuery API",
-        "documentation": {
-          "summary": "A data platform for customers to create, manage, share and query data."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
+      ],
+      "monitoring": {
+        "consumerDestinations": [
           {
-            "type": "bigquery.googleapis.com/Table",
-            "displayName": "BigQuery Table Resource.",
-            "description": "BigQuery Table Resource.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP resource container associated with this resource, such as \"my-project\" or \"organizations/123\u201d."
-              },
-              {
-                "key": "location",
-                "description": "The cloud location of the BigQuery table."
-              },
-              {
-                "key": "table_reference",
-                "description": "The table reference in the format of project_id:dataset_id.table_id for the BigQuery table."
-              }
-            ],
-            "launchStage": "ALPHA"
+            "monitoredResource": "serviceruntime.googleapis.com/api",
+            "metrics": [
+              "serviceruntime.googleapis.com/api/consumer/request_count",
+              "serviceruntime.googleapis.com/api/consumer/error_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
+              "serviceruntime.googleapis.com/api/consumer/total_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+              "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_sizes",
+              "serviceruntime.googleapis.com/api/consumer/response_sizes",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+              "serviceruntime.googleapis.com/quota/used",
+              "serviceruntime.googleapis.com/quota/limit",
+              "serviceruntime.googleapis.com/quota/exceeded",
+              "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+            ]
           },
           {
-            "type": "bigquery.googleapis.com/Location",
-            "displayName": "CheckIamPolicy Request Location",
-            "description": "A BigQuery Location (sometimes called Region).",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The id of the GCP resource container associated with this resource."
-              },
-              {
-                "key": "location",
-                "description": "Location of resource."
-              }
-            ],
-            "launchStage": "ALPHA"
+            "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
+            "metrics": [
+              "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
+              "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
+              "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
+              "serviceruntime.googleapis.com/quota/consumer/limit",
+              "serviceruntime.googleapis.com/quota/consumer/exceeded"
+            ]
           }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/autoscaling.googleapis.com",
+    "config": {
+      "name": "autoscaling.googleapis.com",
+      "title": "Cloud Autoscaling API",
+      "documentation": {
+        "summary": "An API for the Cloud Autoscaling for consuming autoscaling signals.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+    "name": "projects/413204024550/services/bigquery.googleapis.com",
+    "config": {
+      "name": "bigquery.googleapis.com",
+      "title": "BigQuery API",
+      "documentation": {
+        "summary": "A data platform for customers to create, manage, share and query data."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "bigquery.googleapis.com/Table",
+          "displayName": "BigQuery Table Resource.",
+          "description": "BigQuery Table Resource.",
+          "labels": [
             {
-              "monitoredResource": "bigquery.googleapis.com/Table",
-              "metrics": [
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org/exceeded",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_eu/exceeded",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_us/exceeded",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project/exceeded",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_eu/exceeded",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_us/exceeded"
-              ]
+              "key": "resource_container",
+              "description": "The identifier of the GCP resource container associated with this resource, such as \"my-project\" or \"organizations/123\u201d."
             },
             {
-              "monitoredResource": "bigquery.googleapis.com/Table",
-              "metrics": [
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org/limit",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org/usage",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_eu/limit",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_eu/usage",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_us/limit",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_us/usage",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project/limit",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project/usage",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_eu/limit",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_eu/usage",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_us/limit",
-                "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_us/usage"
-              ]
+              "key": "location",
+              "description": "The cloud location of the BigQuery table."
             },
             {
-              "monitoredResource": "bigquery.googleapis.com/Location",
-              "metrics": [
-                "bigquery.googleapis.com/quota/internalCheckIamPolicyRequests/exceeded",
-                "bigquery.googleapis.com/quota/internalCheckIamPolicyRequests/usage"
-              ]
+              "key": "table_reference",
+              "description": "The table reference in the format of project_id:dataset_id.table_id for the BigQuery table."
+            }
+          ],
+          "launchStage": "ALPHA"
+        },
+        {
+          "type": "bigquery.googleapis.com/Location",
+          "displayName": "CheckIamPolicy Request Location",
+          "description": "A BigQuery Location (sometimes called Region).",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The id of the GCP resource container associated with this resource."
             },
             {
-              "monitoredResource": "bigquery.googleapis.com/Location",
-              "metrics": [
-                "bigquery.googleapis.com/quota/internalCheckIamPolicyRequests/limit"
-              ]
+              "key": "location",
+              "description": "Location of resource."
+            }
+          ],
+          "launchStage": "ALPHA"
+        }
+      ],
+      "monitoring": {
+        "consumerDestinations": [
+          {
+            "monitoredResource": "bigquery.googleapis.com/Table",
+            "metrics": [
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org/exceeded",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_eu/exceeded",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_us/exceeded",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project/exceeded",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_eu/exceeded",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_us/exceeded"
+            ]
+          },
+          {
+            "monitoredResource": "bigquery.googleapis.com/Table",
+            "metrics": [
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org/limit",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org/usage",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_eu/limit",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_eu/usage",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_us/limit",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_org_us/usage",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project/limit",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project/usage",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_eu/limit",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_eu/usage",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_us/limit",
+              "bigquery.googleapis.com/quota/internal/table/base_table_bytes_for_free_indexing_per_project_us/usage"
+            ]
+          },
+          {
+            "monitoredResource": "bigquery.googleapis.com/Location",
+            "metrics": [
+              "bigquery.googleapis.com/quota/internalCheckIamPolicyRequests/exceeded",
+              "bigquery.googleapis.com/quota/internalCheckIamPolicyRequests/usage"
+            ]
+          },
+          {
+            "monitoredResource": "bigquery.googleapis.com/Location",
+            "metrics": [
+              "bigquery.googleapis.com/quota/internalCheckIamPolicyRequests/limit"
+            ]
+          }
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/bigquerymigration.googleapis.com",
+    "config": {
+      "name": "bigquerymigration.googleapis.com",
+      "title": "BigQuery Migration API",
+      "documentation": {
+        "summary": "The migration service, exposing apis for migration jobs operations, and agent management."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/bigquerystorage.googleapis.com",
+    "config": {
+      "name": "bigquerystorage.googleapis.com",
+      "title": "BigQuery Storage API",
+      "documentation": {},
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/bigtable.googleapis.com",
+    "config": {
+      "name": "bigtable.googleapis.com",
+      "title": "Cloud Bigtable API",
+      "documentation": {
+        "summary": "API for reading and writing the contents of Bigtables associated with a cloud project."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/bigtableadmin.googleapis.com",
+    "config": {
+      "name": "bigtableadmin.googleapis.com",
+      "title": "Cloud Bigtable Admin API",
+      "documentation": {
+        "summary": "Administer your Cloud Bigtable tables and instances."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/cloudapis.googleapis.com",
+    "config": {
+      "name": "cloudapis.googleapis.com",
+      "title": "Google Cloud APIs",
+      "documentation": {
+        "summary": "This is a meta service for Google Cloud APIs for convenience. Enabling this service enables all commonly used Google Cloud APIs for the project. By default, it is enabled for all projects created through Google Cloud Console and Google Cloud SDK, and should be manually enabled for all other projects that intend to use Google Cloud APIs. Note: disabling this service has no effect on other services.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/cloudbuild.googleapis.com",
+    "config": {
+      "name": "cloudbuild.googleapis.com",
+      "title": "Cloud Build API",
+      "documentation": {
+        "summary": "Creates and manages builds on Google Cloud Platform."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud",
+          "serviceusage.googleapis.com/billing-enabled"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "cloudbuild.googleapis.com/Location",
+          "displayName": "Cloud Build Location",
+          "description": "A location in the Cloud Build API.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identified of the GCP resource container associated with this resource, such as \"my_project\" or \"organizations/5678\"."
+            },
+            {
+              "key": "location",
+              "description": "Location of resource."
+            }
+          ],
+          "launchStage": "ALPHA"
+        },
+        {
+          "type": "cloudbuild.googleapis.com/GkeInstance",
+          "displayName": "GKE instance",
+          "description": "GKE instance.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP resource container associated with this resource, such as \"my_project\" or \"organizations/5678\"."
+            },
+            {
+              "key": "location",
+              "description": "Location of resource."
+            },
+            {
+              "key": "gke_instance_id",
+              "description": "The identifier of the GKE instance."
+            }
+          ],
+          "launchStage": "ALPHA"
+        },
+        {
+          "type": "cloudbuild.googleapis.com/PrivatePool",
+          "displayName": "Private Worker Pool",
+          "description": "Private Worker Pool.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP resource container associated with this resource, such as \"my_project\" or \"organizations/5678\"."
+            },
+            {
+              "key": "location",
+              "description": "Location of resource."
+            },
+            {
+              "key": "worker_pool_uuid",
+              "description": "The UUID of the worker pool."
+            }
+          ],
+          "launchStage": "ALPHA"
+        }
+      ],
+      "monitoring": {
+        "consumerDestinations": [
+          {
+            "monitoredResource": "cloudbuild.googleapis.com/Location",
+            "metrics": [
+              "cloudbuild.googleapis.com/concurrent_public_pool_build_cpus",
+              "cloudbuild.googleapis.com/quota/concurrent_public_pool_build_cpus/exceeded"
+            ]
+          },
+          {
+            "monitoredResource": "cloudbuild.googleapis.com/Location",
+            "metrics": [
+              "cloudbuild.googleapis.com/quota/concurrent_public_pool_build_cpus/limit",
+              "cloudbuild.googleapis.com/quota/concurrent_public_pool_build_cpus/usage"
+            ]
+          },
+          {
+            "monitoredResource": "cloudbuild.googleapis.com/GkeInstance",
+            "metrics": [
+              "cloudbuild.googleapis.com/internal/gke_instance/pod",
+              "cloudbuild.googleapis.com/internal/gke_instance/node"
+            ]
+          },
+          {
+            "monitoredResource": "cloudbuild.googleapis.com/PrivatePool",
+            "metrics": [
+              "cloudbuild.googleapis.com/internal/private_pool_ready_worker_replicas"
+            ]
+          }
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/clouddebugger.googleapis.com",
+    "config": {
+      "name": "clouddebugger.googleapis.com",
+      "title": "Cloud Debugger API",
+      "documentation": {
+        "summary": "Examines the call stack and variables of a running application without stopping or slowing it down.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/cloudfunctions.googleapis.com",
+    "config": {
+      "name": "cloudfunctions.googleapis.com",
+      "title": "Cloud Functions API",
+      "documentation": {
+        "summary": "Manages lightweight user-provided functions executed in response to events."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "cloudfunctions.googleapis.com/function",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "cloudfunctions.googleapis.com/function_name"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/api",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_version"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_method"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/consumer_project"
+            },
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/consumer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/producer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/consumer_resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
             }
           ]
         }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/bigquerymigration.googleapis.com",
-      "config": {
-        "name": "bigquerymigration.googleapis.com",
-        "title": "BigQuery Migration API",
-        "documentation": {
-          "summary": "The migration service, exposing apis for migration jobs operations, and agent management."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/bigquerystorage.googleapis.com",
-      "config": {
-        "name": "bigquerystorage.googleapis.com",
-        "title": "BigQuery Storage API",
-        "documentation": {},
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/bigtable.googleapis.com",
-      "config": {
-        "name": "bigtable.googleapis.com",
-        "title": "Cloud Bigtable API",
-        "documentation": {
-          "summary": "API for reading and writing the contents of Bigtables associated with a cloud project."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/bigtableadmin.googleapis.com",
-      "config": {
-        "name": "bigtableadmin.googleapis.com",
-        "title": "Cloud Bigtable Admin API",
-        "documentation": {
-          "summary": "Administer your Cloud Bigtable tables and instances."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/cloudapis.googleapis.com",
-      "config": {
-        "name": "cloudapis.googleapis.com",
-        "title": "Google Cloud APIs",
-        "documentation": {
-          "summary": "This is a meta service for Google Cloud APIs for convenience. Enabling this service enables all commonly used Google Cloud APIs for the project. By default, it is enabled for all projects created through Google Cloud Console and Google Cloud SDK, and should be manually enabled for all other projects that intend to use Google Cloud APIs. Note: disabling this service has no effect on other services.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/cloudbuild.googleapis.com",
-      "config": {
-        "name": "cloudbuild.googleapis.com",
-        "title": "Cloud Build API",
-        "documentation": {
-          "summary": "Creates and manages builds on Google Cloud Platform."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud",
-            "serviceusage.googleapis.com/billing-enabled"
-          ]
-        },
-        "monitoredResources": [
+      ],
+      "monitoring": {
+        "consumerDestinations": [
           {
-            "type": "cloudbuild.googleapis.com/Location",
-            "displayName": "Cloud Build Location",
-            "description": "A location in the Cloud Build API.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identified of the GCP resource container associated with this resource, such as \"my_project\" or \"organizations/5678\"."
-              },
-              {
-                "key": "location",
-                "description": "Location of resource."
-              }
-            ],
-            "launchStage": "ALPHA"
+            "monitoredResource": "cloudfunctions.googleapis.com/function",
+            "metrics": [
+              "cloudfunctions.googleapis.com/function/execution_times",
+              "cloudfunctions.googleapis.com/function/execution_count",
+              "cloudfunctions.googleapis.com/function/user_memory_bytes",
+              "cloudfunctions.googleapis.com/function/network_egress",
+              "cloudfunctions.googleapis.com/function/active_instances",
+              "cloudfunctions.googleapis.com/function/execution_delays",
+              "cloudfunctions.googleapis.com/function/execution_count_internal",
+              "cloudfunctions.googleapis.com/function/supervisor_gcu_times",
+              "cloudfunctions.googleapis.com/function/supervisor_memory_bytes",
+              "cloudfunctions.googleapis.com/function/user_gcu_times",
+              "cloudfunctions.googleapis.com/function/supervisor_chemist_rpc_error_count",
+              "cloudfunctions.googleapis.com/function/supervisor_controlled_death_count",
+              "cloudfunctions.googleapis.com/function/supervisor_report_count",
+              "cloudfunctions.googleapis.com/function/supervisor_report_latencies",
+              "cloudfunctions.googleapis.com/function/supervisor_phase_latencies"
+            ]
           },
           {
-            "type": "cloudbuild.googleapis.com/GkeInstance",
-            "displayName": "GKE instance",
-            "description": "GKE instance.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP resource container associated with this resource, such as \"my_project\" or \"organizations/5678\"."
-              },
-              {
-                "key": "location",
-                "description": "Location of resource."
-              },
-              {
-                "key": "gke_instance_id",
-                "description": "The identifier of the GKE instance."
-              }
-            ],
-            "launchStage": "ALPHA"
+            "monitoredResource": "serviceruntime.googleapis.com/api",
+            "metrics": [
+              "serviceruntime.googleapis.com/api/consumer/request_count",
+              "serviceruntime.googleapis.com/api/consumer/error_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
+              "serviceruntime.googleapis.com/api/consumer/total_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+              "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_sizes",
+              "serviceruntime.googleapis.com/api/consumer/response_sizes",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+              "serviceruntime.googleapis.com/quota/used",
+              "serviceruntime.googleapis.com/quota/limit",
+              "serviceruntime.googleapis.com/quota/exceeded",
+              "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+            ]
           },
           {
-            "type": "cloudbuild.googleapis.com/PrivatePool",
-            "displayName": "Private Worker Pool",
-            "description": "Private Worker Pool.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP resource container associated with this resource, such as \"my_project\" or \"organizations/5678\"."
-              },
-              {
-                "key": "location",
-                "description": "Location of resource."
-              },
-              {
-                "key": "worker_pool_uuid",
-                "description": "The UUID of the worker pool."
-              }
-            ],
-            "launchStage": "ALPHA"
+            "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
+            "metrics": [
+              "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
+              "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
+              "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
+              "serviceruntime.googleapis.com/quota/consumer/limit",
+              "serviceruntime.googleapis.com/quota/consumer/exceeded"
+            ]
           }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/cloudkms.googleapis.com",
+    "config": {
+      "name": "cloudkms.googleapis.com",
+      "title": "Cloud Key Management Service (KMS) API",
+      "documentation": {
+        "summary": "Manages keys and performs cryptographic operations in a central cloud service, for direct use by other cloud resources and applications.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "cloudkms.googleapis.com/Project",
+          "displayName": "KMS project",
+          "description": "KMS project.",
+          "labels": [
             {
-              "monitoredResource": "cloudbuild.googleapis.com/Location",
-              "metrics": [
-                "cloudbuild.googleapis.com/concurrent_public_pool_build_cpus",
-                "cloudbuild.googleapis.com/quota/concurrent_public_pool_build_cpus/exceeded"
-              ]
+              "key": "resource_container",
+              "description": "The identifier of the GCP project associated with this resource."
             },
             {
-              "monitoredResource": "cloudbuild.googleapis.com/Location",
-              "metrics": [
-                "cloudbuild.googleapis.com/quota/concurrent_public_pool_build_cpus/limit",
-                "cloudbuild.googleapis.com/quota/concurrent_public_pool_build_cpus/usage"
-              ]
+              "key": "location",
+              "description": "The location of the resource."
+            }
+          ],
+          "launchStage": "GA"
+        }
+      ],
+      "monitoring": {
+        "consumerDestinations": [
+          {
+            "monitoredResource": "cloudkms.googleapis.com/Project",
+            "metrics": [
+              "cloudkms.googleapis.com/ekm/external/request_count",
+              "cloudkms.googleapis.com/ekm/external/request_latencies",
+              "cloudkms.googleapis.com/external_kms_multiregion_requests",
+              "cloudkms.googleapis.com/hsm_multiregion_asymmetric_requests",
+              "cloudkms.googleapis.com/hsm_multiregion_symmetric_requests",
+              "cloudkms.googleapis.com/peak_qps",
+              "cloudkms.googleapis.com/quota/external_kms_multiregion_requests/exceeded",
+              "cloudkms.googleapis.com/quota/external_kms_multiregion_requests/usage",
+              "cloudkms.googleapis.com/quota/hsm_multiregion_asymmetric_requests/exceeded",
+              "cloudkms.googleapis.com/quota/hsm_multiregion_asymmetric_requests/usage",
+              "cloudkms.googleapis.com/quota/hsm_multiregion_symmetric_requests/exceeded",
+              "cloudkms.googleapis.com/quota/hsm_multiregion_symmetric_requests/usage",
+              "cloudkms.googleapis.com/quota/software_multiregion_asymmetric_requests/exceeded",
+              "cloudkms.googleapis.com/quota/software_multiregion_asymmetric_requests/usage",
+              "cloudkms.googleapis.com/quota/software_multiregion_symmetric_requests/exceeded",
+              "cloudkms.googleapis.com/quota/software_multiregion_symmetric_requests/usage"
+            ]
+          },
+          {
+            "monitoredResource": "cloudkms.googleapis.com/Project",
+            "metrics": [
+              "cloudkms.googleapis.com/quota/external_kms_multiregion_requests/limit",
+              "cloudkms.googleapis.com/quota/hsm_multiregion_asymmetric_requests/limit",
+              "cloudkms.googleapis.com/quota/hsm_multiregion_symmetric_requests/limit",
+              "cloudkms.googleapis.com/quota/software_multiregion_asymmetric_requests/limit",
+              "cloudkms.googleapis.com/quota/software_multiregion_symmetric_requests/limit"
+            ]
+          }
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/cloudresourcemanager.googleapis.com",
+    "config": {
+      "name": "cloudresourcemanager.googleapis.com",
+      "title": "Cloud Resource Manager API",
+      "documentation": {
+        "summary": "Creates, reads, and updates metadata for Google Cloud Platform resource containers."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "serviceruntime.googleapis.com/api",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
             },
             {
-              "monitoredResource": "cloudbuild.googleapis.com/GkeInstance",
-              "metrics": [
-                "cloudbuild.googleapis.com/internal/gke_instance/pod",
-                "cloudbuild.googleapis.com/internal/gke_instance/node"
-              ]
+              "key": "cloud.googleapis.com/uid"
             },
             {
-              "monitoredResource": "cloudbuild.googleapis.com/PrivatePool",
-              "metrics": [
-                "cloudbuild.googleapis.com/internal/private_pool_ready_worker_replicas"
-              ]
+              "key": "serviceruntime.googleapis.com/api_version"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_method"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/consumer_project"
+            },
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/consumer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/producer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/consumer_resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
             }
           ]
         }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/clouddebugger.googleapis.com",
-      "config": {
-        "name": "clouddebugger.googleapis.com",
-        "title": "Cloud Debugger API",
-        "documentation": {
-          "summary": "Examines the call stack and variables of a running application without stopping or slowing it down.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/cloudfunctions.googleapis.com",
-      "config": {
-        "name": "cloudfunctions.googleapis.com",
-        "title": "Cloud Functions API",
-        "documentation": {
-          "summary": "Manages lightweight user-provided functions executed in response to events."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
+      ],
+      "monitoring": {
+        "consumerDestinations": [
           {
-            "type": "cloudfunctions.googleapis.com/function",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "cloudfunctions.googleapis.com/function_name"
-              }
+            "monitoredResource": "serviceruntime.googleapis.com/api",
+            "metrics": [
+              "serviceruntime.googleapis.com/api/consumer/request_count",
+              "serviceruntime.googleapis.com/api/consumer/error_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
+              "serviceruntime.googleapis.com/api/consumer/total_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+              "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_sizes",
+              "serviceruntime.googleapis.com/api/consumer/response_sizes",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+              "serviceruntime.googleapis.com/quota/used",
+              "serviceruntime.googleapis.com/quota/limit",
+              "serviceruntime.googleapis.com/quota/exceeded",
+              "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
             ]
           },
           {
-            "type": "serviceruntime.googleapis.com/api",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_version"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_method"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/consumer_project"
-              },
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/consumer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/producer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/consumer_resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
+            "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
+            "metrics": [
+              "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
+              "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
+              "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
+              "serviceruntime.googleapis.com/quota/consumer/limit",
+              "serviceruntime.googleapis.com/quota/consumer/exceeded"
             ]
           }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/cloudtrace.googleapis.com",
+    "config": {
+      "name": "cloudtrace.googleapis.com",
+      "title": "Cloud Trace API",
+      "documentation": {
+        "summary": "Sends application trace data to Cloud Trace for viewing. Trace data is collected for all App Engine applications by default. Trace data from other applications can be provided using this API. This library is used to interact with the Cloud Trace API directly. If you are looking to instrument your application for Cloud Trace, we recommend using OpenTelemetry.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "cloudtrace.googleapis.com/charged_project",
+          "labels": [
             {
-              "monitoredResource": "cloudfunctions.googleapis.com/function",
-              "metrics": [
-                "cloudfunctions.googleapis.com/function/execution_times",
-                "cloudfunctions.googleapis.com/function/execution_count",
-                "cloudfunctions.googleapis.com/function/user_memory_bytes",
-                "cloudfunctions.googleapis.com/function/network_egress",
-                "cloudfunctions.googleapis.com/function/active_instances",
-                "cloudfunctions.googleapis.com/function/execution_delays",
-                "cloudfunctions.googleapis.com/function/execution_count_internal",
-                "cloudfunctions.googleapis.com/function/supervisor_gcu_times",
-                "cloudfunctions.googleapis.com/function/supervisor_memory_bytes",
-                "cloudfunctions.googleapis.com/function/user_gcu_times",
-                "cloudfunctions.googleapis.com/function/supervisor_chemist_rpc_error_count",
-                "cloudfunctions.googleapis.com/function/supervisor_controlled_death_count",
-                "cloudfunctions.googleapis.com/function/supervisor_report_count",
-                "cloudfunctions.googleapis.com/function/supervisor_report_latencies",
-                "cloudfunctions.googleapis.com/function/supervisor_phase_latencies"
-              ]
+              "key": "cloud.googleapis.com/project"
             },
             {
-              "monitoredResource": "serviceruntime.googleapis.com/api",
-              "metrics": [
-                "serviceruntime.googleapis.com/api/consumer/request_count",
-                "serviceruntime.googleapis.com/api/consumer/error_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_used_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
-                "serviceruntime.googleapis.com/api/consumer/total_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
-                "serviceruntime.googleapis.com/api/consumer/backend_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_sizes",
-                "serviceruntime.googleapis.com/api/consumer/response_sizes",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
-                "serviceruntime.googleapis.com/quota/used",
-                "serviceruntime.googleapis.com/quota/limit",
-                "serviceruntime.googleapis.com/quota/exceeded",
-                "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
-              ]
+              "key": "monitoring.googleapis.com/service"
             },
             {
-              "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
-              "metrics": [
-                "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
-                "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
-                "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
-                "serviceruntime.googleapis.com/quota/consumer/limit",
-                "serviceruntime.googleapis.com/quota/consumer/exceeded"
-              ]
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            }
+          ]
+        },
+        {
+          "type": "cloudtrace.googleapis.com/ChargedProject",
+          "displayName": "Cloud trace target",
+          "description": "A cloud trace specialization target schema of cloud.ChargedProject.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The monitored resource container. Could be project, workspace, etc."
+            },
+            {
+              "key": "location",
+              "description": "The service-specific notion of location."
+            },
+            {
+              "key": "api_service",
+              "description": "The name of the API service with which the data is associated (e.g.,'cloudtrace.googleapis.com')."
+            }
+          ],
+          "launchStage": "ALPHA"
+        },
+        {
+          "type": "cloudtrace.googleapis.com/CloudtraceProject",
+          "displayName": "Cloud Trace",
+          "description": "Cloud trace resource, e.g. project.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP container associated with the resource."
+            },
+            {
+              "key": "location",
+              "description": "The location that the Cloud Trace service recording the metrics is running."
+            }
+          ],
+          "launchStage": "EARLY_ACCESS"
+        }
+      ],
+      "monitoring": {
+        "consumerDestinations": [
+          {
+            "monitoredResource": "cloudtrace.googleapis.com/ChargedProject",
+            "metrics": [
+              "cloudtrace.googleapis.com/billing/ingested_spans"
+            ]
+          },
+          {
+            "monitoredResource": "cloudtrace.googleapis.com/charged_project",
+            "metrics": [
+              "cloudtrace.googleapis.com/billing/retrieved_spans"
+            ]
+          },
+          {
+            "monitoredResource": "cloudtrace.googleapis.com/CloudtraceProject",
+            "metrics": [
+              "cloudtrace.googleapis.com/internal/plugin_server_span_count",
+              "cloudtrace.googleapis.com/internal/reader_root_query_count",
+              "cloudtrace.googleapis.com/internal/reader_root_query_latencies",
+              "cloudtrace.googleapis.com/bigquery_export/exported_span_count"
+            ]
+          }
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/compute.googleapis.com",
+    "config": {
+      "name": "compute.googleapis.com",
+      "title": "Compute Engine API",
+      "documentation": {
+        "summary": "Creates and runs virtual machines on Google Cloud Platform.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud",
+          "serviceusage.googleapis.com/billing-enabled"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "compute.googleapis.com/VpcNetwork",
+          "displayName": "VPC Network",
+          "description": "VPC Network.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP container (i.e. project) associated with the VPC Network."
+            },
+            {
+              "key": "location",
+              "description": "Location of the VPC Network, global always."
+            },
+            {
+              "key": "network_id",
+              "description": "VPC Network resource ID."
+            }
+          ],
+          "launchStage": "GA"
+        },
+        {
+          "type": "compute.googleapis.com/Location",
+          "displayName": "Compute Location",
+          "description": "A location in the Compute API.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP container (i.e. project) associated with the Compute Location."
+            },
+            {
+              "key": "location",
+              "description": "Location of resource."
+            }
+          ],
+          "launchStage": "GA"
+        },
+        {
+          "type": "compute.googleapis.com/Reservation",
+          "displayName": "Reservation",
+          "description": "Monitored resource representing a reservation.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The GCP container (e.g. project number) associated with the reservation."
+            },
+            {
+              "key": "location",
+              "description": "The zone that contains the reservation."
+            },
+            {
+              "key": "reservation_id",
+              "description": "Reservation resource ID."
+            }
+          ],
+          "launchStage": "ALPHA"
+        },
+        {
+          "type": "gce_instance",
+          "displayName": "VM Instance",
+          "description": "A virtual machine instance hosted in Compute Engine.",
+          "labels": [
+            {
+              "key": "project_id",
+              "description": "The identifier of the GCP project associated with this resource, such as \"my-project\"."
+            },
+            {
+              "key": "instance_id",
+              "description": "The numeric VM instance identifier assigned by Compute Engine."
+            },
+            {
+              "key": "zone",
+              "description": "The Compute Engine zone in which the VM is running."
+            }
+          ],
+          "launchStage": "GA"
+        }
+      ],
+      "monitoring": {
+        "consumerDestinations": [
+          {
+            "monitoredResource": "compute.googleapis.com/VpcNetwork",
+            "metrics": [
+              "compute.googleapis.com/instances_per_vpc_network",
+              "compute.googleapis.com/internal_lb_forwarding_rules_per_vpc_network",
+              "compute.googleapis.com/internal_managed_forwarding_rules_per_vpc_network",
+              "compute.googleapis.com/internal_protocol_forwarding_rules_per_vpc_network",
+              "compute.googleapis.com/ip_aliases_per_vpc_network",
+              "compute.googleapis.com/psc_google_apis_forwarding_rules_per_vpc_network",
+              "compute.googleapis.com/psc_ilb_consumer_forwarding_rules_per_producer_vpc_network",
+              "compute.googleapis.com/quota/global_internal_managed_forwarding_rules_per_region_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/instances_per_peering_group/exceeded",
+              "compute.googleapis.com/quota/instances_per_regional_vpc_network/exceeded",
+              "compute.googleapis.com/quota/instances_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/exceeded",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_regional_vpc_network/exceeded",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/exceeded",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_regional_vpc_network/exceeded",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_peering_group/exceeded",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_regional_vpc_network/exceeded",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/ip_aliases_per_peering_group/exceeded",
+              "compute.googleapis.com/quota/ip_aliases_per_regional_vpc_network/exceeded",
+              "compute.googleapis.com/quota/ip_aliases_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/psc_google_apis_forwarding_rules_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_regional_vpc_network/exceeded",
+              "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_vpc_network/exceeded",
+              "compute.googleapis.com/quota/regional_external_managed_forwarding_rules_per_region_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/regional_internal_managed_forwarding_rules_per_region_per_vpc_network/exceeded",
+              "compute.googleapis.com/quota/static_routes_per_peering_group/exceeded",
+              "compute.googleapis.com/quota/subnet_ranges_per_peering_group/exceeded",
+              "compute.googleapis.com/quota/subnet_ranges_per_regional_vpc_network/exceeded",
+              "compute.googleapis.com/quota/subnet_ranges_per_vpc_network/exceeded",
+              "compute.googleapis.com/subnet_ranges_per_vpc_network"
+            ]
+          },
+          {
+            "monitoredResource": "compute.googleapis.com/Location",
+            "metrics": [
+              "compute.googleapis.com/global_dns/request_count",
+              "compute.googleapis.com/local_ssd_total_storage_per_vm_family",
+              "compute.googleapis.com/quota/cpus_per_vm_family/exceeded",
+              "compute.googleapis.com/quota/gpus_per_gpu_family/exceeded",
+              "compute.googleapis.com/quota/local_ssd_total_storage_per_vm_family/exceeded",
+              "compute.googleapis.com/quota/preemptible_gpus_per_gpu_family/exceeded",
+              "compute.googleapis.com/quota/reserved_resource_per_aggregate_reservation_per_cluster/exceeded"
+            ]
+          },
+          {
+            "monitoredResource": "compute.googleapis.com/Location",
+            "metrics": [
+              "compute.googleapis.com/quota/cpus_per_vm_family/limit",
+              "compute.googleapis.com/quota/cpus_per_vm_family/usage",
+              "compute.googleapis.com/quota/gpus_per_gpu_family/limit",
+              "compute.googleapis.com/quota/gpus_per_gpu_family/usage",
+              "compute.googleapis.com/quota/local_ssd_total_storage_per_vm_family/limit",
+              "compute.googleapis.com/quota/local_ssd_total_storage_per_vm_family/usage",
+              "compute.googleapis.com/quota/preemptible_gpus_per_gpu_family/limit",
+              "compute.googleapis.com/quota/preemptible_gpus_per_gpu_family/usage",
+              "compute.googleapis.com/quota/reserved_resource_per_aggregate_reservation_per_cluster/limit",
+              "compute.googleapis.com/quota/reserved_resource_per_aggregate_reservation_per_cluster/usage"
+            ]
+          },
+          {
+            "monitoredResource": "compute.googleapis.com/VpcNetwork",
+            "metrics": [
+              "compute.googleapis.com/quota/global_internal_managed_forwarding_rules_per_region_per_vpc_network/limit",
+              "compute.googleapis.com/quota/global_internal_managed_forwarding_rules_per_region_per_vpc_network/usage",
+              "compute.googleapis.com/quota/instances_per_peering_group/limit",
+              "compute.googleapis.com/quota/instances_per_peering_group/usage",
+              "compute.googleapis.com/quota/instances_per_regional_vpc_network/limit",
+              "compute.googleapis.com/quota/instances_per_regional_vpc_network/usage",
+              "compute.googleapis.com/quota/instances_per_vpc_network/limit",
+              "compute.googleapis.com/quota/instances_per_vpc_network/usage",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/limit",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/usage",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_regional_vpc_network/limit",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_regional_vpc_network/usage",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/limit",
+              "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/usage",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/limit",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/usage",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_regional_vpc_network/limit",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_regional_vpc_network/usage",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/limit",
+              "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/usage",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_peering_group/limit",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_peering_group/usage",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_regional_vpc_network/limit",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_regional_vpc_network/usage",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_vpc_network/limit",
+              "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_vpc_network/usage",
+              "compute.googleapis.com/quota/ip_aliases_per_peering_group/limit",
+              "compute.googleapis.com/quota/ip_aliases_per_peering_group/usage",
+              "compute.googleapis.com/quota/ip_aliases_per_regional_vpc_network/limit",
+              "compute.googleapis.com/quota/ip_aliases_per_regional_vpc_network/usage",
+              "compute.googleapis.com/quota/ip_aliases_per_vpc_network/limit",
+              "compute.googleapis.com/quota/ip_aliases_per_vpc_network/usage",
+              "compute.googleapis.com/quota/psc_google_apis_forwarding_rules_per_vpc_network/limit",
+              "compute.googleapis.com/quota/psc_google_apis_forwarding_rules_per_vpc_network/usage",
+              "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_regional_vpc_network/limit",
+              "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_regional_vpc_network/usage",
+              "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_vpc_network/limit",
+              "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_vpc_network/usage",
+              "compute.googleapis.com/quota/regional_external_managed_forwarding_rules_per_region_per_vpc_network/limit",
+              "compute.googleapis.com/quota/regional_external_managed_forwarding_rules_per_region_per_vpc_network/usage",
+              "compute.googleapis.com/quota/regional_internal_managed_forwarding_rules_per_region_per_vpc_network/limit",
+              "compute.googleapis.com/quota/regional_internal_managed_forwarding_rules_per_region_per_vpc_network/usage",
+              "compute.googleapis.com/quota/static_routes_per_peering_group/limit",
+              "compute.googleapis.com/quota/static_routes_per_peering_group/usage",
+              "compute.googleapis.com/quota/subnet_ranges_per_peering_group/limit",
+              "compute.googleapis.com/quota/subnet_ranges_per_peering_group/usage",
+              "compute.googleapis.com/quota/subnet_ranges_per_regional_vpc_network/limit",
+              "compute.googleapis.com/quota/subnet_ranges_per_regional_vpc_network/usage",
+              "compute.googleapis.com/quota/subnet_ranges_per_vpc_network/limit",
+              "compute.googleapis.com/quota/subnet_ranges_per_vpc_network/usage"
+            ]
+          },
+          {
+            "monitoredResource": "compute.googleapis.com/Reservation",
+            "metrics": [
+              "compute.googleapis.com/reservation/reserved",
+              "compute.googleapis.com/reservation/assured",
+              "compute.googleapis.com/reservation/used"
+            ]
+          },
+          {
+            "monitoredResource": "gce_instance",
+            "metrics": [
+              "compute.googleapis.com/instance/global_dns/request_count"
+            ]
+          }
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/container.googleapis.com",
+    "config": {
+      "name": "container.googleapis.com",
+      "title": "Kubernetes Engine API",
+      "documentation": {
+        "summary": "Builds and manages container-based applications, powered by the open source Kubernetes technology."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud",
+          "serviceusage.googleapis.com/billing-enabled"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/containerfilesystem.googleapis.com",
+    "config": {
+      "name": "containerfilesystem.googleapis.com",
+      "title": "Container File System API",
+      "documentation": {
+        "summary": "Stream images stored in Artifact Registry to GKE\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/containerregistry.googleapis.com",
+    "config": {
+      "name": "containerregistry.googleapis.com",
+      "title": "Container Registry API",
+      "documentation": {
+        "summary": "Google Container Registry provides secure, private Docker image storage on Google Cloud Platform.  Our API follows the Docker Registry API specification, so we are fully compatible with the Docker CLI client, as well as standard tooling using the Docker Registry API."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud",
+          "serviceusage.googleapis.com/billing-enabled"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/datastore.googleapis.com",
+    "config": {
+      "name": "datastore.googleapis.com",
+      "title": "Cloud Datastore API",
+      "documentation": {
+        "summary": "Accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/dns.googleapis.com",
+    "config": {
+      "name": "dns.googleapis.com",
+      "title": "Cloud DNS API",
+      "documentation": {},
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud",
+          "serviceusage.googleapis.com/billing-enabled"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/file.googleapis.com",
+    "config": {
+      "name": "file.googleapis.com",
+      "title": "Cloud Filestore API",
+      "documentation": {
+        "summary": "The Cloud Filestore API is used for creating and managing cloud file servers."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "filestore_instance",
+          "displayName": "Filestore Instance",
+          "description": "A Filestore instance.",
+          "labels": [
+            {
+              "key": "project_id",
+              "description": "The identifier of the GCP project associated with this resource, such as \"my-project\"."
+            },
+            {
+              "key": "location",
+              "description": "The physical location of the instance."
+            },
+            {
+              "key": "instance_name",
+              "description": "The name for the Filestore instance."
+            }
+          ],
+          "launchStage": "GA"
+        },
+        {
+          "type": "file.googleapis.com/InstanceNode",
+          "displayName": "InstanceNode",
+          "description": "InstanceNode resource represents a VM running as part of a Filestore instance.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP container associated with the resource."
+            },
+            {
+              "key": "service_name",
+              "description": "The name of the SaaS Lifecycle Management service. Format is projects/{project}/services/{service}."
+            },
+            {
+              "key": "location",
+              "description": "GCP location: zone, region, multi-region or other service-specific container."
+            },
+            {
+              "key": "consumer_project_number",
+              "description": "The consumer project number."
+            },
+            {
+              "key": "instance_id",
+              "description": "The name (short) of the instance set by the consumer."
+            },
+            {
+              "key": "instance_uid",
+              "description": "Globally unique identifier of the instance."
+            },
+            {
+              "key": "node_id",
+              "description": "A string used to uniquely distinguish a node within a service instance."
+            }
+          ],
+          "launchStage": "ALPHA"
+        },
+        {
+          "type": "saas_instance",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "saasaccelerator.googleapis.com/service_name"
+            },
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "saasaccelerator.googleapis.com/consumer_project"
+            },
+            {
+              "key": "saasaccelerator.googleapis.com/instance_id"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            }
+          ]
+        },
+        {
+          "type": "saas_instance_node",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "saasaccelerator.googleapis.com/service_name"
+            },
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "saasaccelerator.googleapis.com/consumer_project"
+            },
+            {
+              "key": "saasaccelerator.googleapis.com/instance_id"
+            },
+            {
+              "key": "saasaccelerator.googleapis.com/node_id"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
             }
           ]
         }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/cloudkms.googleapis.com",
-      "config": {
-        "name": "cloudkms.googleapis.com",
-        "title": "Cloud Key Management Service (KMS) API",
-        "documentation": {
-          "summary": "Manages keys and performs cryptographic operations in a central cloud service, for direct use by other cloud resources and applications.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
+      ],
+      "monitoring": {
+        "consumerDestinations": [
           {
-            "type": "cloudkms.googleapis.com/Project",
-            "displayName": "KMS project",
-            "description": "KMS project.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP project associated with this resource."
-              },
-              {
-                "key": "location",
-                "description": "The location of the resource."
-              }
-            ],
-            "launchStage": "GA"
+            "monitoredResource": "filestore_instance",
+            "metrics": [
+              "file.googleapis.com/nfs/server/procedure_call_count",
+              "file.googleapis.com/nfs/server/free_bytes",
+              "file.googleapis.com/nfs/server/used_bytes",
+              "file.googleapis.com/nfs/server/free_bytes_percent",
+              "file.googleapis.com/nfs/server/used_bytes_percent",
+              "file.googleapis.com/nfs/server/read_bytes_count",
+              "file.googleapis.com/nfs/server/write_bytes_count",
+              "file.googleapis.com/nfs/server/read_ops_count",
+              "file.googleapis.com/nfs/server/write_ops_count",
+              "file.googleapis.com/nfs/server/read_milliseconds_count",
+              "file.googleapis.com/nfs/server/write_milliseconds_count",
+              "file.googleapis.com/nfs/server/file_handles",
+              "file.googleapis.com/nfs/server/io",
+              "file.googleapis.com/nfs/server/network",
+              "file.googleapis.com/nfs/server/read_ahead_cache",
+              "file.googleapis.com/nfs/server/reply_cache",
+              "file.googleapis.com/nfs/server/rpc",
+              "file.googleapis.com/nfs/server/threads",
+              "file.googleapis.com/nfs/server/locks",
+              "file.googleapis.com/nfs/server/read_latency",
+              "file.googleapis.com/nfs/server/average_read_latency",
+              "file.googleapis.com/nfs/server/write_latency",
+              "file.googleapis.com/nfs/server/average_write_latency",
+              "file.googleapis.com/nfs/server/metadata_ops_count",
+              "file.googleapis.com/highscale/active_connections",
+              "file.googleapis.com/highscale/hosts_up",
+              "file.googleapis.com/highscale/hosts_total",
+              "file.googleapis.com/nfs/server/metadata_latency",
+              "file.googleapis.com/highscale/devices_total",
+              "file.googleapis.com/highscale/devices_up",
+              "file.googleapis.com/nfs/server/connections",
+              "file.googleapis.com/highscale/efsck/runs",
+              "file.googleapis.com/highscale/efsck/aborts",
+              "file.googleapis.com/nfs/server/free_raw_capacity_percent",
+              "file.googleapis.com/nfs/server/snapshots_used_bytes"
+            ]
+          },
+          {
+            "monitoredResource": "saas_instance",
+            "metrics": [
+              "file.googleapis.com/highscale/snapshot/last_valid_backup_creation_timestamp"
+            ]
+          },
+          {
+            "monitoredResource": "filestore_instance",
+            "metrics": [
+              "file.googleapis.com/highscale/efsck/is_running"
+            ]
           }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+    "name": "projects/413204024550/services/iam.googleapis.com",
+    "config": {
+      "name": "iam.googleapis.com",
+      "title": "Identity and Access Management (IAM) API",
+      "documentation": {
+        "summary": "Manages identity and access control for Google Cloud Platform resources, including the creation of service accounts, which you can use to authenticate to Google and make API calls.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "iam_service_account",
+          "displayName": "IAM Service Account",
+          "description": "An IAM Service Account.",
+          "labels": [
             {
-              "monitoredResource": "cloudkms.googleapis.com/Project",
-              "metrics": [
-                "cloudkms.googleapis.com/ekm/external/request_count",
-                "cloudkms.googleapis.com/ekm/external/request_latencies",
-                "cloudkms.googleapis.com/external_kms_multiregion_requests",
-                "cloudkms.googleapis.com/hsm_multiregion_asymmetric_requests",
-                "cloudkms.googleapis.com/hsm_multiregion_symmetric_requests",
-                "cloudkms.googleapis.com/peak_qps",
-                "cloudkms.googleapis.com/quota/external_kms_multiregion_requests/exceeded",
-                "cloudkms.googleapis.com/quota/external_kms_multiregion_requests/usage",
-                "cloudkms.googleapis.com/quota/hsm_multiregion_asymmetric_requests/exceeded",
-                "cloudkms.googleapis.com/quota/hsm_multiregion_asymmetric_requests/usage",
-                "cloudkms.googleapis.com/quota/hsm_multiregion_symmetric_requests/exceeded",
-                "cloudkms.googleapis.com/quota/hsm_multiregion_symmetric_requests/usage",
-                "cloudkms.googleapis.com/quota/software_multiregion_asymmetric_requests/exceeded",
-                "cloudkms.googleapis.com/quota/software_multiregion_asymmetric_requests/usage",
-                "cloudkms.googleapis.com/quota/software_multiregion_symmetric_requests/exceeded",
-                "cloudkms.googleapis.com/quota/software_multiregion_symmetric_requests/usage"
-              ]
+              "key": "project_id",
+              "description": "The identifier of the GCP project associated with this resource, such as 'my-project'."
             },
             {
-              "monitoredResource": "cloudkms.googleapis.com/Project",
-              "metrics": [
-                "cloudkms.googleapis.com/quota/external_kms_multiregion_requests/limit",
-                "cloudkms.googleapis.com/quota/hsm_multiregion_asymmetric_requests/limit",
-                "cloudkms.googleapis.com/quota/hsm_multiregion_symmetric_requests/limit",
-                "cloudkms.googleapis.com/quota/software_multiregion_asymmetric_requests/limit",
-                "cloudkms.googleapis.com/quota/software_multiregion_symmetric_requests/limit"
-              ]
+              "key": "unique_id",
+              "description": "The unique_id of the service account."
+            }
+          ],
+          "launchStage": "GA"
+        },
+        {
+          "type": "iam.googleapis.com/WorkloadIdentityPoolProvider",
+          "displayName": "Workload Identity Pool Provider",
+          "description": "A workload identity pool provider.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP project associated with this resource, such as 'my-project'."
+            },
+            {
+              "key": "location",
+              "description": "The location of the resource."
+            },
+            {
+              "key": "pool_id",
+              "description": "The ID of the provider's workload identity pool parent resource."
+            },
+            {
+              "key": "provider_id",
+              "description": "The ID of the workload identity pool provider resource."
+            }
+          ],
+          "launchStage": "BETA"
+        }
+      ],
+      "monitoring": {
+        "consumerDestinations": [
+          {
+            "monitoredResource": "iam.googleapis.com/WorkloadIdentityPoolProvider",
+            "metrics": [
+              "iam.googleapis.com/workload_identity_federation/count",
+              "iam.googleapis.com/workload_identity_federation/key_usage_count"
+            ]
+          },
+          {
+            "monitoredResource": "iam_service_account",
+            "metrics": [
+              "iam.googleapis.com/service_account/authn_events_count",
+              "iam.googleapis.com/service_account/key/authn_events_count",
+              "iam.googleapis.com/service_account/authn_events_count_preprod",
+              "iam.googleapis.com/service_account/key/authn_events_count_preprod"
+            ]
+          }
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/iamcredentials.googleapis.com",
+    "config": {
+      "name": "iamcredentials.googleapis.com",
+      "title": "IAM Service Account Credentials API",
+      "documentation": {
+        "summary": "Creates short-lived credentials for impersonating IAM service accounts. To enable this API, you must enable the IAM API (iam.googleapis.com).\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/logging.googleapis.com",
+    "config": {
+      "name": "logging.googleapis.com",
+      "title": "Cloud Logging API",
+      "documentation": {
+        "summary": "Writes log entries and manages your Cloud Logging configuration."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "logging.googleapis.com/ChargedProject",
+          "displayName": "Cloud logging target",
+          "description": "A cloud logging specialization target schema of cloud.ChargedProject.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The monitored resource container. Could be project, workspace, etc."
+            },
+            {
+              "key": "location",
+              "description": "The service-specific notion of location."
+            },
+            {
+              "key": "service",
+              "description": "The name of the API service with which the data is associated (e.g.,'logging.googleapis.com')."
+            }
+          ],
+          "launchStage": "ALPHA"
+        }
+      ],
+      "monitoring": {
+        "consumerDestinations": [
+          {
+            "monitoredResource": "logging.googleapis.com/ChargedProject",
+            "metrics": [
+              "logging.googleapis.com/billing/ingested_bytes",
+              "logging.googleapis.com/billing/stored_bytes"
+            ]
+          }
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/monitoring.googleapis.com",
+    "config": {
+      "name": "monitoring.googleapis.com",
+      "title": "Cloud Monitoring API",
+      "documentation": {
+        "summary": "Manages your Cloud Monitoring data and configurations.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "monitoring.googleapis.com/ChargedProject",
+          "displayName": "Cloud monitoring target",
+          "description": "A cloud monitoring specialization target schema of cloud.ChargedProject.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The monitored resource container. Could be project, workspace, etc."
+            },
+            {
+              "key": "location",
+              "description": "The service-specific notion of location."
+            },
+            {
+              "key": "service",
+              "description": "The name of the API service with which the data is associated (e.g.,'monitoring.googleapis.com')."
+            }
+          ],
+          "launchStage": "ALPHA"
+        },
+        {
+          "type": "monitoring.googleapis.com/MetricStatistics",
+          "displayName": "Metric Statistics",
+          "description": "Information about a user-written metric in Cloud Monitoring.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP project to which the metric is written, such as 'my-project'."
+            },
+            {
+              "key": "location",
+              "description": "The cloud region where the metric was received."
+            },
+            {
+              "key": "metric_type",
+              "description": "The metric type."
+            }
+          ],
+          "launchStage": "BETA"
+        },
+        {
+          "type": "monitoring.googleapis.com/MetricIngestionAttribution",
+          "displayName": "Metric Ingestion Attribution",
+          "description": "Attribution for metric ingestion.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The identifier of the GCP project to which the metric is written, such as 'my-project'."
+            },
+            {
+              "key": "location",
+              "description": "The location of the resource that the metric ingestion was associated with, unless it was 'global', in which case this will be the cloud region where the metric was received."
+            },
+            {
+              "key": "attribution_dimension",
+              "description": "The dimension used for attribution reporting. It is not recommended that aggregations are performed across dimensions because a single metric point can be recorded with multiple dimensions which could cause double counting. Currently only \"namespace\" and \"cluster\" are supported."
+            },
+            {
+              "key": "attribution_id",
+              "description": "The attribution id of the source of the metric write."
+            }
+          ],
+          "launchStage": "BETA"
+        }
+      ],
+      "monitoring": {
+        "consumerDestinations": [
+          {
+            "monitoredResource": "monitoring.googleapis.com/ChargedProject",
+            "metrics": [
+              "monitoring.googleapis.com/billing/bytes_ingested",
+              "monitoring.googleapis.com/billing/samples_ingested"
+            ]
+          },
+          {
+            "monitoredResource": "monitoring.googleapis.com/MetricStatistics",
+            "metrics": [
+              "monitoring.googleapis.com/collection/write_request_count",
+              "monitoring.googleapis.com/collection/write_request_point_count"
+            ]
+          },
+          {
+            "monitoredResource": "monitoring.googleapis.com/MetricIngestionAttribution",
+            "metrics": [
+              "monitoring.googleapis.com/collection/attribution/sample_count",
+              "monitoring.googleapis.com/collection/attribution/write_sample_count"
+            ]
+          }
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/oslogin.googleapis.com",
+    "config": {
+      "name": "oslogin.googleapis.com",
+      "title": "Cloud OS Login API",
+      "documentation": {
+        "summary": "You can use OS Login to manage access to your VM instances using IAM roles."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/pubsub.googleapis.com",
+    "config": {
+      "name": "pubsub.googleapis.com",
+      "title": "Cloud Pub/Sub API",
+      "documentation": {
+        "summary": "Provides reliable, many-to-many, asynchronous messaging between applications.\n"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/servicemanagement.googleapis.com",
+    "config": {
+      "name": "servicemanagement.googleapis.com",
+      "title": "Service Management API",
+      "documentation": {
+        "summary": "Google Service Management allows service producers to publish their services on Google Cloud Platform so that they can be discovered and used by service consumers."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/serviceusage.googleapis.com",
+    "config": {
+      "name": "serviceusage.googleapis.com",
+      "title": "Service Usage API",
+      "documentation": {
+        "summary": "Enables services that service consumers want to use on Google Cloud Platform, lists the available or enabled services, or disables services that service consumers no longer use."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/source.googleapis.com",
+    "config": {
+      "name": "source.googleapis.com",
+      "title": "Legacy Cloud Source Repositories API",
+      "documentation": {
+        "summary": "Access source code repositories hosted by Google."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "serviceruntime.googleapis.com/api",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_version"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_method"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/consumer_project"
+            },
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/consumer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/producer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/consumer_resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
             }
           ]
         }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/cloudresourcemanager.googleapis.com",
-      "config": {
-        "name": "cloudresourcemanager.googleapis.com",
-        "title": "Cloud Resource Manager API",
-        "documentation": {
-          "summary": "Creates, reads, and updates metadata for Google Cloud Platform resource containers."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
+      ],
+      "monitoring": {
+        "consumerDestinations": [
           {
-            "type": "serviceruntime.googleapis.com/api",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_version"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_method"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/consumer_project"
-              },
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              }
+            "monitoredResource": "serviceruntime.googleapis.com/api",
+            "metrics": [
+              "serviceruntime.googleapis.com/api/consumer/request_count",
+              "serviceruntime.googleapis.com/api/consumer/error_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
+              "serviceruntime.googleapis.com/api/consumer/total_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+              "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_sizes",
+              "serviceruntime.googleapis.com/api/consumer/response_sizes",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+              "serviceruntime.googleapis.com/quota/used",
+              "serviceruntime.googleapis.com/quota/limit",
+              "serviceruntime.googleapis.com/quota/exceeded",
+              "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
             ]
           },
           {
-            "type": "serviceruntime.googleapis.com/consumer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/producer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/consumer_resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
+            "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
+            "metrics": [
+              "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
+              "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
+              "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
+              "serviceruntime.googleapis.com/quota/consumer/limit",
+              "serviceruntime.googleapis.com/quota/consumer/exceeded"
             ]
           }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/sourcerepo.googleapis.com",
+    "config": {
+      "name": "sourcerepo.googleapis.com",
+      "title": "Cloud Source Repositories API",
+      "documentation": {
+        "summary": "Accesses source code repositories hosted by Google."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/spanner.googleapis.com",
+    "config": {
+      "name": "spanner.googleapis.com",
+      "title": "Cloud Spanner API",
+      "documentation": {
+        "summary": "Cloud Spanner is a managed, mission-critical, globally consistent and scalable relational database service."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud",
+          "serviceusage.googleapis.com/billing-enabled"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/sql-component.googleapis.com",
+    "config": {
+      "name": "sql-component.googleapis.com",
+      "title": "Cloud SQL",
+      "documentation": {
+        "summary": "Google Cloud SQL is a hosted and fully managed relational database service\n    on Google's infrastructure."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "serviceruntime.googleapis.com/api",
+          "labels": [
             {
-              "monitoredResource": "serviceruntime.googleapis.com/api",
-              "metrics": [
-                "serviceruntime.googleapis.com/api/consumer/request_count",
-                "serviceruntime.googleapis.com/api/consumer/error_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_used_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
-                "serviceruntime.googleapis.com/api/consumer/total_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
-                "serviceruntime.googleapis.com/api/consumer/backend_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_sizes",
-                "serviceruntime.googleapis.com/api/consumer/response_sizes",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
-                "serviceruntime.googleapis.com/quota/used",
-                "serviceruntime.googleapis.com/quota/limit",
-                "serviceruntime.googleapis.com/quota/exceeded",
-                "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
-              ]
+              "key": "cloud.googleapis.com/location"
             },
             {
-              "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
-              "metrics": [
-                "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
-                "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
-                "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
-                "serviceruntime.googleapis.com/quota/consumer/limit",
-                "serviceruntime.googleapis.com/quota/consumer/exceeded"
-              ]
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_version"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_method"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/consumer_project"
+            },
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/consumer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/producer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/consumer_resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
             }
           ]
         }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/cloudtrace.googleapis.com",
-      "config": {
-        "name": "cloudtrace.googleapis.com",
-        "title": "Cloud Trace API",
-        "documentation": {
-          "summary": "Sends application trace data to Cloud Trace for viewing. Trace data is collected for all App Engine applications by default. Trace data from other applications can be provided using this API. This library is used to interact with the Cloud Trace API directly. If you are looking to instrument your application for Cloud Trace, we recommend using OpenTelemetry.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
+      ],
+      "monitoring": {
+        "consumerDestinations": [
           {
-            "type": "cloudtrace.googleapis.com/charged_project",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "monitoring.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              }
+            "monitoredResource": "serviceruntime.googleapis.com/api",
+            "metrics": [
+              "serviceruntime.googleapis.com/api/consumer/request_count",
+              "serviceruntime.googleapis.com/api/consumer/error_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
+              "serviceruntime.googleapis.com/api/consumer/total_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+              "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_sizes",
+              "serviceruntime.googleapis.com/api/consumer/response_sizes",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+              "serviceruntime.googleapis.com/quota/used",
+              "serviceruntime.googleapis.com/quota/limit",
+              "serviceruntime.googleapis.com/quota/exceeded",
+              "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
             ]
           },
           {
-            "type": "cloudtrace.googleapis.com/ChargedProject",
-            "displayName": "Cloud trace target",
-            "description": "A cloud trace specialization target schema of cloud.ChargedProject.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The monitored resource container. Could be project, workspace, etc."
-              },
-              {
-                "key": "location",
-                "description": "The service-specific notion of location."
-              },
-              {
-                "key": "api_service",
-                "description": "The name of the API service with which the data is associated (e.g.,'cloudtrace.googleapis.com')."
-              }
-            ],
-            "launchStage": "ALPHA"
-          },
-          {
-            "type": "cloudtrace.googleapis.com/CloudtraceProject",
-            "displayName": "Cloud Trace",
-            "description": "Cloud trace resource, e.g. project.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP container associated with the resource."
-              },
-              {
-                "key": "location",
-                "description": "The location that the Cloud Trace service recording the metrics is running."
-              }
-            ],
-            "launchStage": "EARLY_ACCESS"
+            "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
+            "metrics": [
+              "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
+              "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
+              "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
+              "serviceruntime.googleapis.com/quota/consumer/limit",
+              "serviceruntime.googleapis.com/quota/consumer/exceeded"
+            ]
           }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/sqladmin.googleapis.com",
+    "config": {
+      "name": "sqladmin.googleapis.com",
+      "title": "Cloud SQL Admin API",
+      "documentation": {
+        "summary": "API for Cloud SQL database instance management"
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud",
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/storage-api.googleapis.com",
+    "config": {
+      "name": "storage-api.googleapis.com",
+      "title": "Google Cloud Storage JSON API",
+      "documentation": {
+        "summary": "Lets you store and retrieve potentially-large, immutable data objects."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoring": {}
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/storage-component.googleapis.com",
+    "config": {
+      "name": "storage-component.googleapis.com",
+      "title": "Cloud Storage",
+      "documentation": {
+        "summary": "Google Cloud Storage is a RESTful service for storing and accessing your data on Google's\n    infrastructure."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "serviceruntime.googleapis.com/api",
+          "labels": [
             {
-              "monitoredResource": "cloudtrace.googleapis.com/ChargedProject",
-              "metrics": [
-                "cloudtrace.googleapis.com/billing/ingested_spans"
-              ]
+              "key": "cloud.googleapis.com/location"
             },
             {
-              "monitoredResource": "cloudtrace.googleapis.com/charged_project",
-              "metrics": [
-                "cloudtrace.googleapis.com/billing/retrieved_spans"
-              ]
+              "key": "cloud.googleapis.com/uid"
             },
             {
-              "monitoredResource": "cloudtrace.googleapis.com/CloudtraceProject",
-              "metrics": [
-                "cloudtrace.googleapis.com/internal/plugin_server_span_count",
-                "cloudtrace.googleapis.com/internal/reader_root_query_count",
-                "cloudtrace.googleapis.com/internal/reader_root_query_latencies",
-                "cloudtrace.googleapis.com/bigquery_export/exported_span_count"
-              ]
+              "key": "serviceruntime.googleapis.com/api_version"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/api_method"
+            },
+            {
+              "key": "serviceruntime.googleapis.com/consumer_project"
+            },
+            {
+              "key": "cloud.googleapis.com/project"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/consumer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
+            }
+          ]
+        },
+        {
+          "type": "serviceruntime.googleapis.com/producer_quota",
+          "labels": [
+            {
+              "key": "cloud.googleapis.com/location"
+            },
+            {
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/service"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_id"
+            },
+            {
+              "key": "cloud.googleapis.com/resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/consumer_resource_node"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_metric"
+            },
+            {
+              "key": "cloud.googleapis.com/quota_location"
             }
           ]
         }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/compute.googleapis.com",
-      "config": {
-        "name": "compute.googleapis.com",
-        "title": "Compute Engine API",
-        "documentation": {
-          "summary": "Creates and runs virtual machines on Google Cloud Platform.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud",
-            "serviceusage.googleapis.com/billing-enabled"
-          ]
-        },
-        "monitoredResources": [
+      ],
+      "monitoring": {
+        "consumerDestinations": [
           {
-            "type": "compute.googleapis.com/VpcNetwork",
-            "displayName": "VPC Network",
-            "description": "VPC Network.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP container (i.e. project) associated with the VPC Network."
-              },
-              {
-                "key": "location",
-                "description": "Location of the VPC Network, global always."
-              },
-              {
-                "key": "network_id",
-                "description": "VPC Network resource ID."
-              }
-            ],
-            "launchStage": "GA"
+            "monitoredResource": "serviceruntime.googleapis.com/api",
+            "metrics": [
+              "serviceruntime.googleapis.com/api/consumer/request_count",
+              "serviceruntime.googleapis.com/api/consumer/error_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+              "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
+              "serviceruntime.googleapis.com/api/consumer/total_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+              "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+              "serviceruntime.googleapis.com/api/consumer/request_sizes",
+              "serviceruntime.googleapis.com/api/consumer/response_sizes",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+              "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+              "serviceruntime.googleapis.com/quota/used",
+              "serviceruntime.googleapis.com/quota/limit",
+              "serviceruntime.googleapis.com/quota/exceeded",
+              "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+            ]
           },
           {
-            "type": "compute.googleapis.com/Location",
-            "displayName": "Compute Location",
-            "description": "A location in the Compute API.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP container (i.e. project) associated with the Compute Location."
-              },
-              {
-                "key": "location",
-                "description": "Location of resource."
-              }
-            ],
-            "launchStage": "GA"
-          },
-          {
-            "type": "compute.googleapis.com/Reservation",
-            "displayName": "Reservation",
-            "description": "Monitored resource representing a reservation.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The GCP container (e.g. project number) associated with the reservation."
-              },
-              {
-                "key": "location",
-                "description": "The zone that contains the reservation."
-              },
-              {
-                "key": "reservation_id",
-                "description": "Reservation resource ID."
-              }
-            ],
-            "launchStage": "ALPHA"
-          },
-          {
-            "type": "gce_instance",
-            "displayName": "VM Instance",
-            "description": "A virtual machine instance hosted in Compute Engine.",
-            "labels": [
-              {
-                "key": "project_id",
-                "description": "The identifier of the GCP project associated with this resource, such as \"my-project\"."
-              },
-              {
-                "key": "instance_id",
-                "description": "The numeric VM instance identifier assigned by Compute Engine."
-              },
-              {
-                "key": "zone",
-                "description": "The Compute Engine zone in which the VM is running."
-              }
-            ],
-            "launchStage": "GA"
+            "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
+            "metrics": [
+              "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
+              "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
+              "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
+              "serviceruntime.googleapis.com/quota/consumer/limit",
+              "serviceruntime.googleapis.com/quota/consumer/exceeded"
+            ]
           }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
+        ]
+      }
+    },
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  },
+  {
+CHECK    "name": "projects/413204024550/services/storage.googleapis.com",
+    "config": {
+      "name": "storage.googleapis.com",
+      "title": "Cloud Storage API",
+      "documentation": {
+        "summary": "Lets you store and retrieve potentially-large, immutable data objects."
+      },
+      "quota": {},
+      "authentication": {},
+      "usage": {
+        "requirements": [
+          "serviceusage.googleapis.com/tos/cloud"
+        ]
+      },
+      "monitoredResources": [
+        {
+          "type": "storage.googleapis.com/StorageLocation",
+          "displayName": "Storage Location of GCS Buckets",
+          "description": "Storage Location of GCS Buckets.",
+          "labels": [
             {
-              "monitoredResource": "compute.googleapis.com/VpcNetwork",
-              "metrics": [
-                "compute.googleapis.com/instances_per_vpc_network",
-                "compute.googleapis.com/internal_lb_forwarding_rules_per_vpc_network",
-                "compute.googleapis.com/internal_managed_forwarding_rules_per_vpc_network",
-                "compute.googleapis.com/internal_protocol_forwarding_rules_per_vpc_network",
-                "compute.googleapis.com/ip_aliases_per_vpc_network",
-                "compute.googleapis.com/psc_google_apis_forwarding_rules_per_vpc_network",
-                "compute.googleapis.com/psc_ilb_consumer_forwarding_rules_per_producer_vpc_network",
-                "compute.googleapis.com/quota/global_internal_managed_forwarding_rules_per_region_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/instances_per_peering_group/exceeded",
-                "compute.googleapis.com/quota/instances_per_regional_vpc_network/exceeded",
-                "compute.googleapis.com/quota/instances_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/exceeded",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_regional_vpc_network/exceeded",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/exceeded",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_regional_vpc_network/exceeded",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_peering_group/exceeded",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_regional_vpc_network/exceeded",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/ip_aliases_per_peering_group/exceeded",
-                "compute.googleapis.com/quota/ip_aliases_per_regional_vpc_network/exceeded",
-                "compute.googleapis.com/quota/ip_aliases_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/psc_google_apis_forwarding_rules_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_regional_vpc_network/exceeded",
-                "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_vpc_network/exceeded",
-                "compute.googleapis.com/quota/regional_external_managed_forwarding_rules_per_region_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/regional_internal_managed_forwarding_rules_per_region_per_vpc_network/exceeded",
-                "compute.googleapis.com/quota/static_routes_per_peering_group/exceeded",
-                "compute.googleapis.com/quota/subnet_ranges_per_peering_group/exceeded",
-                "compute.googleapis.com/quota/subnet_ranges_per_regional_vpc_network/exceeded",
-                "compute.googleapis.com/quota/subnet_ranges_per_vpc_network/exceeded",
-                "compute.googleapis.com/subnet_ranges_per_vpc_network"
-              ]
+              "key": "resource_container",
+              "description": "The project number of the bucket."
             },
             {
-              "monitoredResource": "compute.googleapis.com/Location",
-              "metrics": [
-                "compute.googleapis.com/global_dns/request_count",
-                "compute.googleapis.com/local_ssd_total_storage_per_vm_family",
-                "compute.googleapis.com/quota/cpus_per_vm_family/exceeded",
-                "compute.googleapis.com/quota/gpus_per_gpu_family/exceeded",
-                "compute.googleapis.com/quota/local_ssd_total_storage_per_vm_family/exceeded",
-                "compute.googleapis.com/quota/preemptible_gpus_per_gpu_family/exceeded",
-                "compute.googleapis.com/quota/reserved_resource_per_aggregate_reservation_per_cluster/exceeded"
-              ]
+              "key": "location",
+              "description": "The storage location of the bucket."
+            }
+          ],
+          "launchStage": "EARLY_ACCESS"
+        },
+        {
+          "type": "storage.googleapis.com/Location",
+          "displayName": "GCS Location",
+          "description": "GCS Location.",
+          "labels": [
+            {
+              "key": "resource_container",
+              "description": "The project number of the bucket."
             },
             {
-              "monitoredResource": "compute.googleapis.com/Location",
-              "metrics": [
-                "compute.googleapis.com/quota/cpus_per_vm_family/limit",
-                "compute.googleapis.com/quota/cpus_per_vm_family/usage",
-                "compute.googleapis.com/quota/gpus_per_gpu_family/limit",
-                "compute.googleapis.com/quota/gpus_per_gpu_family/usage",
-                "compute.googleapis.com/quota/local_ssd_total_storage_per_vm_family/limit",
-                "compute.googleapis.com/quota/local_ssd_total_storage_per_vm_family/usage",
-                "compute.googleapis.com/quota/preemptible_gpus_per_gpu_family/limit",
-                "compute.googleapis.com/quota/preemptible_gpus_per_gpu_family/usage",
-                "compute.googleapis.com/quota/reserved_resource_per_aggregate_reservation_per_cluster/limit",
-                "compute.googleapis.com/quota/reserved_resource_per_aggregate_reservation_per_cluster/usage"
-              ]
+              "key": "location",
+              "description": "The location of the bucket."
+            }
+          ],
+          "launchStage": "ALPHA"
+        },
+        {
+          "type": "storage.googleapis.com/storage",
+          "labels": [
+            {
+              "key": "storage.googleapis.com/bucket_name"
             },
             {
-              "monitoredResource": "compute.googleapis.com/VpcNetwork",
-              "metrics": [
-                "compute.googleapis.com/quota/global_internal_managed_forwarding_rules_per_region_per_vpc_network/limit",
-                "compute.googleapis.com/quota/global_internal_managed_forwarding_rules_per_region_per_vpc_network/usage",
-                "compute.googleapis.com/quota/instances_per_peering_group/limit",
-                "compute.googleapis.com/quota/instances_per_peering_group/usage",
-                "compute.googleapis.com/quota/instances_per_regional_vpc_network/limit",
-                "compute.googleapis.com/quota/instances_per_regional_vpc_network/usage",
-                "compute.googleapis.com/quota/instances_per_vpc_network/limit",
-                "compute.googleapis.com/quota/instances_per_vpc_network/usage",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/limit",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_peering_group/usage",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_regional_vpc_network/limit",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_regional_vpc_network/usage",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/limit",
-                "compute.googleapis.com/quota/internal_lb_forwarding_rules_per_vpc_network/usage",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/limit",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_peering_group/usage",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_regional_vpc_network/limit",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_regional_vpc_network/usage",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/limit",
-                "compute.googleapis.com/quota/internal_managed_forwarding_rules_per_vpc_network/usage",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_peering_group/limit",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_peering_group/usage",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_regional_vpc_network/limit",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_regional_vpc_network/usage",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_vpc_network/limit",
-                "compute.googleapis.com/quota/internal_protocol_forwarding_rules_per_vpc_network/usage",
-                "compute.googleapis.com/quota/ip_aliases_per_peering_group/limit",
-                "compute.googleapis.com/quota/ip_aliases_per_peering_group/usage",
-                "compute.googleapis.com/quota/ip_aliases_per_regional_vpc_network/limit",
-                "compute.googleapis.com/quota/ip_aliases_per_regional_vpc_network/usage",
-                "compute.googleapis.com/quota/ip_aliases_per_vpc_network/limit",
-                "compute.googleapis.com/quota/ip_aliases_per_vpc_network/usage",
-                "compute.googleapis.com/quota/psc_google_apis_forwarding_rules_per_vpc_network/limit",
-                "compute.googleapis.com/quota/psc_google_apis_forwarding_rules_per_vpc_network/usage",
-                "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_regional_vpc_network/limit",
-                "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_regional_vpc_network/usage",
-                "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_vpc_network/limit",
-                "compute.googleapis.com/quota/psc_ilb_consumer_forwarding_rules_per_producer_vpc_network/usage",
-                "compute.googleapis.com/quota/regional_external_managed_forwarding_rules_per_region_per_vpc_network/limit",
-                "compute.googleapis.com/quota/regional_external_managed_forwarding_rules_per_region_per_vpc_network/usage",
-                "compute.googleapis.com/quota/regional_internal_managed_forwarding_rules_per_region_per_vpc_network/limit",
-                "compute.googleapis.com/quota/regional_internal_managed_forwarding_rules_per_region_per_vpc_network/usage",
-                "compute.googleapis.com/quota/static_routes_per_peering_group/limit",
-                "compute.googleapis.com/quota/static_routes_per_peering_group/usage",
-                "compute.googleapis.com/quota/subnet_ranges_per_peering_group/limit",
-                "compute.googleapis.com/quota/subnet_ranges_per_peering_group/usage",
-                "compute.googleapis.com/quota/subnet_ranges_per_regional_vpc_network/limit",
-                "compute.googleapis.com/quota/subnet_ranges_per_regional_vpc_network/usage",
-                "compute.googleapis.com/quota/subnet_ranges_per_vpc_network/limit",
-                "compute.googleapis.com/quota/subnet_ranges_per_vpc_network/usage"
-              ]
+              "key": "storage.googleapis.com/bucket_storage_class"
             },
             {
-              "monitoredResource": "compute.googleapis.com/Reservation",
-              "metrics": [
-                "compute.googleapis.com/reservation/reserved",
-                "compute.googleapis.com/reservation/assured",
-                "compute.googleapis.com/reservation/used"
-              ]
+              "key": "cloud.googleapis.com/location"
             },
             {
-              "monitoredResource": "gce_instance",
-              "metrics": [
-                "compute.googleapis.com/instance/global_dns/request_count"
-              ]
+              "key": "cloud.googleapis.com/uid"
+            },
+            {
+              "key": "cloud.googleapis.com/project"
             }
           ]
         }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/container.googleapis.com",
-      "config": {
-        "name": "container.googleapis.com",
-        "title": "Kubernetes Engine API",
-        "documentation": {
-          "summary": "Builds and manages container-based applications, powered by the open source Kubernetes technology."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud",
-            "serviceusage.googleapis.com/billing-enabled"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/containerfilesystem.googleapis.com",
-      "config": {
-        "name": "containerfilesystem.googleapis.com",
-        "title": "Container File System API",
-        "documentation": {
-          "summary": "Stream images stored in Artifact Registry to GKE\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/containerregistry.googleapis.com",
-      "config": {
-        "name": "containerregistry.googleapis.com",
-        "title": "Container Registry API",
-        "documentation": {
-          "summary": "Google Container Registry provides secure, private Docker image storage on Google Cloud Platform.  Our API follows the Docker Registry API specification, so we are fully compatible with the Docker CLI client, as well as standard tooling using the Docker Registry API."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud",
-            "serviceusage.googleapis.com/billing-enabled"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/datastore.googleapis.com",
-      "config": {
-        "name": "datastore.googleapis.com",
-        "title": "Cloud Datastore API",
-        "documentation": {
-          "summary": "Accesses the schemaless NoSQL database to provide fully managed, robust, scalable storage for your application.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/dns.googleapis.com",
-      "config": {
-        "name": "dns.googleapis.com",
-        "title": "Cloud DNS API",
-        "documentation": {},
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud",
-            "serviceusage.googleapis.com/billing-enabled"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/file.googleapis.com",
-      "config": {
-        "name": "file.googleapis.com",
-        "title": "Cloud Filestore API",
-        "documentation": {
-          "summary": "The Cloud Filestore API is used for creating and managing cloud file servers."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
+      ],
+      "monitoring": {
+        "consumerDestinations": [
           {
-            "type": "filestore_instance",
-            "displayName": "Filestore Instance",
-            "description": "A Filestore instance.",
-            "labels": [
-              {
-                "key": "project_id",
-                "description": "The identifier of the GCP project associated with this resource, such as \"my-project\"."
-              },
-              {
-                "key": "location",
-                "description": "The physical location of the instance."
-              },
-              {
-                "key": "instance_name",
-                "description": "The name for the Filestore instance."
-              }
-            ],
-            "launchStage": "GA"
-          },
-          {
-            "type": "file.googleapis.com/InstanceNode",
-            "displayName": "InstanceNode",
-            "description": "InstanceNode resource represents a VM running as part of a Filestore instance.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP container associated with the resource."
-              },
-              {
-                "key": "service_name",
-                "description": "The name of the SaaS Lifecycle Management service. Format is projects/{project}/services/{service}."
-              },
-              {
-                "key": "location",
-                "description": "GCP location: zone, region, multi-region or other service-specific container."
-              },
-              {
-                "key": "consumer_project_number",
-                "description": "The consumer project number."
-              },
-              {
-                "key": "instance_id",
-                "description": "The name (short) of the instance set by the consumer."
-              },
-              {
-                "key": "instance_uid",
-                "description": "Globally unique identifier of the instance."
-              },
-              {
-                "key": "node_id",
-                "description": "A string used to uniquely distinguish a node within a service instance."
-              }
-            ],
-            "launchStage": "ALPHA"
-          },
-          {
-            "type": "saas_instance",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "saasaccelerator.googleapis.com/service_name"
-              },
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "saasaccelerator.googleapis.com/consumer_project"
-              },
-              {
-                "key": "saasaccelerator.googleapis.com/instance_id"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              }
+            "monitoredResource": "storage.googleapis.com/storage",
+            "metrics": [
+              "storage.googleapis.com/storage/total_bytes",
+              "storage.googleapis.com/storage/object_count"
             ]
           },
           {
-            "type": "saas_instance_node",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "saasaccelerator.googleapis.com/service_name"
-              },
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "saasaccelerator.googleapis.com/consumer_project"
-              },
-              {
-                "key": "saasaccelerator.googleapis.com/instance_id"
-              },
-              {
-                "key": "saasaccelerator.googleapis.com/node_id"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              }
+            "monitoredResource": "storage.googleapis.com/StorageLocation",
+            "metrics": [
+              "storage.googleapis.com/quota/in_multi_region_read_bandwidth/exceeded",
+              "storage.googleapis.com/quota/in_multi_region_read_bandwidth/usage",
+              "storage.googleapis.com/quota/in_multi_region_read_bandwidth_preview/exceeded",
+              "storage.googleapis.com/quota/in_multi_region_read_bandwidth_preview/usage"
+            ]
+          },
+          {
+            "monitoredResource": "storage.googleapis.com/Location",
+            "metrics": [
+              "storage.googleapis.com/quota/turbo_replication_ingress_bandwidth/exceeded",
+              "storage.googleapis.com/quota/turbo_replication_ingress_bandwidth/usage"
+            ]
+          },
+          {
+            "monitoredResource": "storage.googleapis.com/StorageLocation",
+            "metrics": [
+              "storage.googleapis.com/quota/in_multi_region_read_bandwidth/limit",
+              "storage.googleapis.com/quota/in_multi_region_read_bandwidth_preview/limit"
+            ]
+          },
+          {
+            "monitoredResource": "storage.googleapis.com/Location",
+            "metrics": [
+              "storage.googleapis.com/quota/turbo_replication_ingress_bandwidth/limit"
             ]
           }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
-            {
-              "monitoredResource": "filestore_instance",
-              "metrics": [
-                "file.googleapis.com/nfs/server/procedure_call_count",
-                "file.googleapis.com/nfs/server/free_bytes",
-                "file.googleapis.com/nfs/server/used_bytes",
-                "file.googleapis.com/nfs/server/free_bytes_percent",
-                "file.googleapis.com/nfs/server/used_bytes_percent",
-                "file.googleapis.com/nfs/server/read_bytes_count",
-                "file.googleapis.com/nfs/server/write_bytes_count",
-                "file.googleapis.com/nfs/server/read_ops_count",
-                "file.googleapis.com/nfs/server/write_ops_count",
-                "file.googleapis.com/nfs/server/read_milliseconds_count",
-                "file.googleapis.com/nfs/server/write_milliseconds_count",
-                "file.googleapis.com/nfs/server/file_handles",
-                "file.googleapis.com/nfs/server/io",
-                "file.googleapis.com/nfs/server/network",
-                "file.googleapis.com/nfs/server/read_ahead_cache",
-                "file.googleapis.com/nfs/server/reply_cache",
-                "file.googleapis.com/nfs/server/rpc",
-                "file.googleapis.com/nfs/server/threads",
-                "file.googleapis.com/nfs/server/locks",
-                "file.googleapis.com/nfs/server/read_latency",
-                "file.googleapis.com/nfs/server/average_read_latency",
-                "file.googleapis.com/nfs/server/write_latency",
-                "file.googleapis.com/nfs/server/average_write_latency",
-                "file.googleapis.com/nfs/server/metadata_ops_count",
-                "file.googleapis.com/highscale/active_connections",
-                "file.googleapis.com/highscale/hosts_up",
-                "file.googleapis.com/highscale/hosts_total",
-                "file.googleapis.com/nfs/server/metadata_latency",
-                "file.googleapis.com/highscale/devices_total",
-                "file.googleapis.com/highscale/devices_up",
-                "file.googleapis.com/nfs/server/connections",
-                "file.googleapis.com/highscale/efsck/runs",
-                "file.googleapis.com/highscale/efsck/aborts",
-                "file.googleapis.com/nfs/server/free_raw_capacity_percent",
-                "file.googleapis.com/nfs/server/snapshots_used_bytes"
-              ]
-            },
-            {
-              "monitoredResource": "saas_instance",
-              "metrics": [
-                "file.googleapis.com/highscale/snapshot/last_valid_backup_creation_timestamp"
-              ]
-            },
-            {
-              "monitoredResource": "filestore_instance",
-              "metrics": [
-                "file.googleapis.com/highscale/efsck/is_running"
-              ]
-            }
-          ]
-        }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
+        ]
+      }
     },
-    {
-      "name": "projects/413204024550/services/iam.googleapis.com",
-      "config": {
-        "name": "iam.googleapis.com",
-        "title": "Identity and Access Management (IAM) API",
-        "documentation": {
-          "summary": "Manages identity and access control for Google Cloud Platform resources, including the creation of service accounts, which you can use to authenticate to Google and make API calls.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
-          {
-            "type": "iam_service_account",
-            "displayName": "IAM Service Account",
-            "description": "An IAM Service Account.",
-            "labels": [
-              {
-                "key": "project_id",
-                "description": "The identifier of the GCP project associated with this resource, such as 'my-project'."
-              },
-              {
-                "key": "unique_id",
-                "description": "The unique_id of the service account."
-              }
-            ],
-            "launchStage": "GA"
-          },
-          {
-            "type": "iam.googleapis.com/WorkloadIdentityPoolProvider",
-            "displayName": "Workload Identity Pool Provider",
-            "description": "A workload identity pool provider.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP project associated with this resource, such as 'my-project'."
-              },
-              {
-                "key": "location",
-                "description": "The location of the resource."
-              },
-              {
-                "key": "pool_id",
-                "description": "The ID of the provider's workload identity pool parent resource."
-              },
-              {
-                "key": "provider_id",
-                "description": "The ID of the workload identity pool provider resource."
-              }
-            ],
-            "launchStage": "BETA"
-          }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
-            {
-              "monitoredResource": "iam.googleapis.com/WorkloadIdentityPoolProvider",
-              "metrics": [
-                "iam.googleapis.com/workload_identity_federation/count",
-                "iam.googleapis.com/workload_identity_federation/key_usage_count"
-              ]
-            },
-            {
-              "monitoredResource": "iam_service_account",
-              "metrics": [
-                "iam.googleapis.com/service_account/authn_events_count",
-                "iam.googleapis.com/service_account/key/authn_events_count",
-                "iam.googleapis.com/service_account/authn_events_count_preprod",
-                "iam.googleapis.com/service_account/key/authn_events_count_preprod"
-              ]
-            }
-          ]
-        }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/iamcredentials.googleapis.com",
-      "config": {
-        "name": "iamcredentials.googleapis.com",
-        "title": "IAM Service Account Credentials API",
-        "documentation": {
-          "summary": "Creates short-lived credentials for impersonating IAM service accounts. To enable this API, you must enable the IAM API (iam.googleapis.com).\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/logging.googleapis.com",
-      "config": {
-        "name": "logging.googleapis.com",
-        "title": "Cloud Logging API",
-        "documentation": {
-          "summary": "Writes log entries and manages your Cloud Logging configuration."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
-          {
-            "type": "logging.googleapis.com/ChargedProject",
-            "displayName": "Cloud logging target",
-            "description": "A cloud logging specialization target schema of cloud.ChargedProject.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The monitored resource container. Could be project, workspace, etc."
-              },
-              {
-                "key": "location",
-                "description": "The service-specific notion of location."
-              },
-              {
-                "key": "service",
-                "description": "The name of the API service with which the data is associated (e.g.,'logging.googleapis.com')."
-              }
-            ],
-            "launchStage": "ALPHA"
-          }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
-            {
-              "monitoredResource": "logging.googleapis.com/ChargedProject",
-              "metrics": [
-                "logging.googleapis.com/billing/ingested_bytes",
-                "logging.googleapis.com/billing/stored_bytes"
-              ]
-            }
-          ]
-        }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/monitoring.googleapis.com",
-      "config": {
-        "name": "monitoring.googleapis.com",
-        "title": "Cloud Monitoring API",
-        "documentation": {
-          "summary": "Manages your Cloud Monitoring data and configurations.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
-          {
-            "type": "monitoring.googleapis.com/ChargedProject",
-            "displayName": "Cloud monitoring target",
-            "description": "A cloud monitoring specialization target schema of cloud.ChargedProject.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The monitored resource container. Could be project, workspace, etc."
-              },
-              {
-                "key": "location",
-                "description": "The service-specific notion of location."
-              },
-              {
-                "key": "service",
-                "description": "The name of the API service with which the data is associated (e.g.,'monitoring.googleapis.com')."
-              }
-            ],
-            "launchStage": "ALPHA"
-          },
-          {
-            "type": "monitoring.googleapis.com/MetricStatistics",
-            "displayName": "Metric Statistics",
-            "description": "Information about a user-written metric in Cloud Monitoring.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP project to which the metric is written, such as 'my-project'."
-              },
-              {
-                "key": "location",
-                "description": "The cloud region where the metric was received."
-              },
-              {
-                "key": "metric_type",
-                "description": "The metric type."
-              }
-            ],
-            "launchStage": "BETA"
-          },
-          {
-            "type": "monitoring.googleapis.com/MetricIngestionAttribution",
-            "displayName": "Metric Ingestion Attribution",
-            "description": "Attribution for metric ingestion.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The identifier of the GCP project to which the metric is written, such as 'my-project'."
-              },
-              {
-                "key": "location",
-                "description": "The location of the resource that the metric ingestion was associated with, unless it was 'global', in which case this will be the cloud region where the metric was received."
-              },
-              {
-                "key": "attribution_dimension",
-                "description": "The dimension used for attribution reporting. It is not recommended that aggregations are performed across dimensions because a single metric point can be recorded with multiple dimensions which could cause double counting. Currently only \"namespace\" and \"cluster\" are supported."
-              },
-              {
-                "key": "attribution_id",
-                "description": "The attribution id of the source of the metric write."
-              }
-            ],
-            "launchStage": "BETA"
-          }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
-            {
-              "monitoredResource": "monitoring.googleapis.com/ChargedProject",
-              "metrics": [
-                "monitoring.googleapis.com/billing/bytes_ingested",
-                "monitoring.googleapis.com/billing/samples_ingested"
-              ]
-            },
-            {
-              "monitoredResource": "monitoring.googleapis.com/MetricStatistics",
-              "metrics": [
-                "monitoring.googleapis.com/collection/write_request_count",
-                "monitoring.googleapis.com/collection/write_request_point_count"
-              ]
-            },
-            {
-              "monitoredResource": "monitoring.googleapis.com/MetricIngestionAttribution",
-              "metrics": [
-                "monitoring.googleapis.com/collection/attribution/sample_count",
-                "monitoring.googleapis.com/collection/attribution/write_sample_count"
-              ]
-            }
-          ]
-        }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/oslogin.googleapis.com",
-      "config": {
-        "name": "oslogin.googleapis.com",
-        "title": "Cloud OS Login API",
-        "documentation": {
-          "summary": "You can use OS Login to manage access to your VM instances using IAM roles."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/pubsub.googleapis.com",
-      "config": {
-        "name": "pubsub.googleapis.com",
-        "title": "Cloud Pub/Sub API",
-        "documentation": {
-          "summary": "Provides reliable, many-to-many, asynchronous messaging between applications.\n"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/servicemanagement.googleapis.com",
-      "config": {
-        "name": "servicemanagement.googleapis.com",
-        "title": "Service Management API",
-        "documentation": {
-          "summary": "Google Service Management allows service producers to publish their services on Google Cloud Platform so that they can be discovered and used by service consumers."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/serviceusage.googleapis.com",
-      "config": {
-        "name": "serviceusage.googleapis.com",
-        "title": "Service Usage API",
-        "documentation": {
-          "summary": "Enables services that service consumers want to use on Google Cloud Platform, lists the available or enabled services, or disables services that service consumers no longer use."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/source.googleapis.com",
-      "config": {
-        "name": "source.googleapis.com",
-        "title": "Legacy Cloud Source Repositories API",
-        "documentation": {
-          "summary": "Access source code repositories hosted by Google."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
-          {
-            "type": "serviceruntime.googleapis.com/api",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_version"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_method"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/consumer_project"
-              },
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/consumer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/producer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/consumer_resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
-            {
-              "monitoredResource": "serviceruntime.googleapis.com/api",
-              "metrics": [
-                "serviceruntime.googleapis.com/api/consumer/request_count",
-                "serviceruntime.googleapis.com/api/consumer/error_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_used_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
-                "serviceruntime.googleapis.com/api/consumer/total_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
-                "serviceruntime.googleapis.com/api/consumer/backend_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_sizes",
-                "serviceruntime.googleapis.com/api/consumer/response_sizes",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
-                "serviceruntime.googleapis.com/quota/used",
-                "serviceruntime.googleapis.com/quota/limit",
-                "serviceruntime.googleapis.com/quota/exceeded",
-                "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
-              ]
-            },
-            {
-              "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
-              "metrics": [
-                "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
-                "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
-                "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
-                "serviceruntime.googleapis.com/quota/consumer/limit",
-                "serviceruntime.googleapis.com/quota/consumer/exceeded"
-              ]
-            }
-          ]
-        }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/sourcerepo.googleapis.com",
-      "config": {
-        "name": "sourcerepo.googleapis.com",
-        "title": "Cloud Source Repositories API",
-        "documentation": {
-          "summary": "Accesses source code repositories hosted by Google."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/spanner.googleapis.com",
-      "config": {
-        "name": "spanner.googleapis.com",
-        "title": "Cloud Spanner API",
-        "documentation": {
-          "summary": "Cloud Spanner is a managed, mission-critical, globally consistent and scalable relational database service."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud",
-            "serviceusage.googleapis.com/billing-enabled"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/sql-component.googleapis.com",
-      "config": {
-        "name": "sql-component.googleapis.com",
-        "title": "Cloud SQL",
-        "documentation": {
-          "summary": "Google Cloud SQL is a hosted and fully managed relational database service\n    on Google's infrastructure."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
-          {
-            "type": "serviceruntime.googleapis.com/api",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_version"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_method"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/consumer_project"
-              },
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/consumer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/producer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/consumer_resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
-            {
-              "monitoredResource": "serviceruntime.googleapis.com/api",
-              "metrics": [
-                "serviceruntime.googleapis.com/api/consumer/request_count",
-                "serviceruntime.googleapis.com/api/consumer/error_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_used_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
-                "serviceruntime.googleapis.com/api/consumer/total_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
-                "serviceruntime.googleapis.com/api/consumer/backend_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_sizes",
-                "serviceruntime.googleapis.com/api/consumer/response_sizes",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
-                "serviceruntime.googleapis.com/quota/used",
-                "serviceruntime.googleapis.com/quota/limit",
-                "serviceruntime.googleapis.com/quota/exceeded",
-                "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
-              ]
-            },
-            {
-              "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
-              "metrics": [
-                "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
-                "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
-                "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
-                "serviceruntime.googleapis.com/quota/consumer/limit",
-                "serviceruntime.googleapis.com/quota/consumer/exceeded"
-              ]
-            }
-          ]
-        }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/sqladmin.googleapis.com",
-      "config": {
-        "name": "sqladmin.googleapis.com",
-        "title": "Cloud SQL Admin API",
-        "documentation": {
-          "summary": "API for Cloud SQL database instance management"
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud",
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/storage-api.googleapis.com",
-      "config": {
-        "name": "storage-api.googleapis.com",
-        "title": "Google Cloud Storage JSON API",
-        "documentation": {
-          "summary": "Lets you store and retrieve potentially-large, immutable data objects."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoring": {}
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/storage-component.googleapis.com",
-      "config": {
-        "name": "storage-component.googleapis.com",
-        "title": "Cloud Storage",
-        "documentation": {
-          "summary": "Google Cloud Storage is a RESTful service for storing and accessing your data on Google's\n    infrastructure."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
-          {
-            "type": "serviceruntime.googleapis.com/api",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_version"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/api_method"
-              },
-              {
-                "key": "serviceruntime.googleapis.com/consumer_project"
-              },
-              {
-                "key": "cloud.googleapis.com/project"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/consumer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          },
-          {
-            "type": "serviceruntime.googleapis.com/producer_quota",
-            "labels": [
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/service"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_id"
-              },
-              {
-                "key": "cloud.googleapis.com/resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/consumer_resource_node"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_metric"
-              },
-              {
-                "key": "cloud.googleapis.com/quota_location"
-              }
-            ]
-          }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
-            {
-              "monitoredResource": "serviceruntime.googleapis.com/api",
-              "metrics": [
-                "serviceruntime.googleapis.com/api/consumer/request_count",
-                "serviceruntime.googleapis.com/api/consumer/error_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_used_count",
-                "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
-                "serviceruntime.googleapis.com/api/consumer/total_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
-                "serviceruntime.googleapis.com/api/consumer/backend_latencies",
-                "serviceruntime.googleapis.com/api/consumer/request_sizes",
-                "serviceruntime.googleapis.com/api/consumer/response_sizes",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
-                "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
-                "serviceruntime.googleapis.com/quota/used",
-                "serviceruntime.googleapis.com/quota/limit",
-                "serviceruntime.googleapis.com/quota/exceeded",
-                "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
-              ]
-            },
-            {
-              "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
-              "metrics": [
-                "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
-                "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
-                "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
-                "serviceruntime.googleapis.com/quota/consumer/limit",
-                "serviceruntime.googleapis.com/quota/consumer/exceeded"
-              ]
-            }
-          ]
-        }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    },
-    {
-CHECK      "name": "projects/413204024550/services/storage.googleapis.com",
-      "config": {
-        "name": "storage.googleapis.com",
-        "title": "Cloud Storage API",
-        "documentation": {
-          "summary": "Lets you store and retrieve potentially-large, immutable data objects."
-        },
-        "quota": {},
-        "authentication": {},
-        "usage": {
-          "requirements": [
-            "serviceusage.googleapis.com/tos/cloud"
-          ]
-        },
-        "monitoredResources": [
-          {
-            "type": "storage.googleapis.com/StorageLocation",
-            "displayName": "Storage Location of GCS Buckets",
-            "description": "Storage Location of GCS Buckets.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The project number of the bucket."
-              },
-              {
-                "key": "location",
-                "description": "The storage location of the bucket."
-              }
-            ],
-            "launchStage": "EARLY_ACCESS"
-          },
-          {
-            "type": "storage.googleapis.com/Location",
-            "displayName": "GCS Location",
-            "description": "GCS Location.",
-            "labels": [
-              {
-                "key": "resource_container",
-                "description": "The project number of the bucket."
-              },
-              {
-                "key": "location",
-                "description": "The location of the bucket."
-              }
-            ],
-            "launchStage": "ALPHA"
-          },
-          {
-            "type": "storage.googleapis.com/storage",
-            "labels": [
-              {
-                "key": "storage.googleapis.com/bucket_name"
-              },
-              {
-                "key": "storage.googleapis.com/bucket_storage_class"
-              },
-              {
-                "key": "cloud.googleapis.com/location"
-              },
-              {
-                "key": "cloud.googleapis.com/uid"
-              },
-              {
-                "key": "cloud.googleapis.com/project"
-              }
-            ]
-          }
-        ],
-        "monitoring": {
-          "consumerDestinations": [
-            {
-              "monitoredResource": "storage.googleapis.com/storage",
-              "metrics": [
-                "storage.googleapis.com/storage/total_bytes",
-                "storage.googleapis.com/storage/object_count"
-              ]
-            },
-            {
-              "monitoredResource": "storage.googleapis.com/StorageLocation",
-              "metrics": [
-                "storage.googleapis.com/quota/in_multi_region_read_bandwidth/exceeded",
-                "storage.googleapis.com/quota/in_multi_region_read_bandwidth/usage",
-                "storage.googleapis.com/quota/in_multi_region_read_bandwidth_preview/exceeded",
-                "storage.googleapis.com/quota/in_multi_region_read_bandwidth_preview/usage"
-              ]
-            },
-            {
-              "monitoredResource": "storage.googleapis.com/Location",
-              "metrics": [
-                "storage.googleapis.com/quota/turbo_replication_ingress_bandwidth/exceeded",
-                "storage.googleapis.com/quota/turbo_replication_ingress_bandwidth/usage"
-              ]
-            },
-            {
-              "monitoredResource": "storage.googleapis.com/StorageLocation",
-              "metrics": [
-                "storage.googleapis.com/quota/in_multi_region_read_bandwidth/limit",
-                "storage.googleapis.com/quota/in_multi_region_read_bandwidth_preview/limit"
-              ]
-            },
-            {
-              "monitoredResource": "storage.googleapis.com/Location",
-              "metrics": [
-                "storage.googleapis.com/quota/turbo_replication_ingress_bandwidth/limit"
-              ]
-            }
-          ]
-        }
-      },
-      "state": "ENABLED",
-      "parent": "projects/413204024550"
-    }
-  ]
+    "state": "ENABLED",
+    "parent": "projects/413204024550"
+  }
 ]

--- a/test/sourcerepos
+++ b/test/sourcerepos
@@ -1,8 +1,6 @@
 [
-  [
-    {
-CHECK      "name": "projects/test-gcp-scanner/repos/test_source_repo",
-CHECK      "url": "https://source.developers.google.com/p/test-gcp-scanner/r/test_source_repo"
-    }
-  ]
+  {
+CHECK    "name": "projects/test-gcp-scanner/repos/test_source_repo",
+CHECK    "url": "https://source.developers.google.com/p/test-gcp-scanner/r/test_source_repo"
+  }
 ]

--- a/test/storage_buckets
+++ b/test/storage_buckets
@@ -1,164 +1,149 @@
 {
-CHECK  "gcf-sources-413204024550-us-central1": [
-    {
-CHECK      "kind": "storage#bucket",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/gcf-sources-413204024550-us-central1",
-      "id": "gcf-sources-413204024550-us-central1",
-CHECK      "name": "gcf-sources-413204024550-us-central1",
-CHECK      "projectNumber": "413204024550",
-      "metageneration": "1",
-CHECK      "location": "US-CENTRAL1",
-      "storageClass": "STANDARD",
-      "etag": "CAE=",
-      "timeCreated": "2022-06-07T03:12:30.376Z",
-      "updated": "2022-06-07T03:12:30.376Z",
-      "cors": [
-        {
-          "origin": [
-            "https://*.cloud.google.com",
-            "https://*.corp.google.com",
-            "https://*.corp.google.com:*"
-          ],
-          "method": [
-            "GET"
-          ]
-        }
-      ],
-      "iamConfiguration": {
-        "bucketPolicyOnly": {
-          "enabled": true,
-          "lockedTime": "2022-09-05T03:12:30.376Z"
-        },
-        "uniformBucketLevelAccess": {
-          "enabled": true,
-          "lockedTime": "2022-09-05T03:12:30.376Z"
-        },
-        "publicAccessPrevention": "inherited"
-      },
-      "locationType": "region"
-    },
-    null
-  ],
-CHECK  "gcp-scanner-test-bucket": [
-    {
-      "kind": "storage#bucket",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/gcp-scanner-test-bucket",
-CHECK      "id": "gcp-scanner-test-bucket",
-CHECK      "name": "gcp-scanner-test-bucket",
-CHECK      "projectNumber": "413204024550",
-      "metageneration": "1",
-      "location": "US",
-      "storageClass": "STANDARD",
-      "etag": "CAE=",
-      "timeCreated": "2022-06-07T02:54:46.416Z",
-      "updated": "2022-06-07T02:54:46.416Z",
-      "iamConfiguration": {
-        "bucketPolicyOnly": {
-          "enabled": true,
-          "lockedTime": "2022-09-05T02:54:46.416Z"
-        },
-        "uniformBucketLevelAccess": {
-          "enabled": true,
-          "lockedTime": "2022-09-05T02:54:46.416Z"
-        },
-        "publicAccessPrevention": "inherited"
-      },
-      "locationType": "multi-region",
-      "rpo": "DEFAULT"
-    },
-    null
-  ],
-CHECK  "staging.test-gcp-scanner.appspot.com": [
-    {
-      "kind": "storage#bucket",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/staging.test-gcp-scanner.appspot.com",
-CHECK      "id": "staging.test-gcp-scanner.appspot.com",
-CHECK      "name": "staging.test-gcp-scanner.appspot.com",
-      "projectNumber": "413204024550",
-      "metageneration": "1",
-      "location": "US",
-      "storageClass": "STANDARD",
-      "etag": "CAE=",
-      "timeCreated": "2022-06-07T03:24:29.093Z",
-      "updated": "2022-06-07T03:24:29.093Z",
-      "lifecycle": {
-        "rule": [
-          {
-            "action": {
-              "type": "Delete"
-            },
-            "condition": {
-              "age": 15
-            }
-          }
+CHECK  "gcf-sources-413204024550-us-central1": {
+CHECK    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/gcf-sources-413204024550-us-central1",
+    "id": "gcf-sources-413204024550-us-central1",
+CHECK    "name": "gcf-sources-413204024550-us-central1",
+CHECK    "projectNumber": "413204024550",
+    "metageneration": "1",
+CHECK    "location": "US-CENTRAL1",
+    "storageClass": "STANDARD",
+    "etag": "CAE=",
+    "timeCreated": "2022-06-07T03:12:30.376Z",
+    "updated": "2022-06-07T03:12:30.376Z",
+    "cors": [
+      {
+        "origin": [
+          "https://*.cloud.google.com",
+          "https://*.corp.google.com",
+          "https://*.corp.google.com:*"
+        ],
+        "method": [
+          "GET"
         ]
+      }
+    ],
+    "iamConfiguration": {
+      "bucketPolicyOnly": {
+        "enabled": true,
+        "lockedTime": "2022-09-05T03:12:30.376Z"
       },
-      "iamConfiguration": {
-        "bucketPolicyOnly": {
-          "enabled": false
-        },
-        "uniformBucketLevelAccess": {
-          "enabled": false
-        },
-        "publicAccessPrevention": "inherited"
+      "uniformBucketLevelAccess": {
+        "enabled": true,
+        "lockedTime": "2022-09-05T03:12:30.376Z"
       },
-      "locationType": "multi-region",
-      "rpo": "DEFAULT"
+      "publicAccessPrevention": "inherited"
     },
-    null
+    "locationType": "region"
+  },
+CHECK  "gcp-scanner-test-bucket": {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/gcp-scanner-test-bucket",
+CHECK    "id": "gcp-scanner-test-bucket",
+CHECK    "name": "gcp-scanner-test-bucket",
+CHECK    "projectNumber": "413204024550",
+    "metageneration": "1",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAE=",
+    "timeCreated": "2022-06-07T02:54:46.416Z",
+    "updated": "2022-06-07T02:54:46.416Z",
+    "iamConfiguration": {
+      "bucketPolicyOnly": {
+        "enabled": true,
+        "lockedTime": "2022-09-05T02:54:46.416Z"
+      },
+      "uniformBucketLevelAccess": {
+        "enabled": true,
+        "lockedTime": "2022-09-05T02:54:46.416Z"
+      },
+      "publicAccessPrevention": "inherited"
+    },
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
   ],
-CHECK  "test-gcp-scanner.appspot.com": [
-    {
-      "kind": "storage#bucket",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/test-gcp-scanner.appspot.com",
-CHECK      "id": "test-gcp-scanner.appspot.com",
-CHECK      "name": "test-gcp-scanner.appspot.com",
-      "projectNumber": "413204024550",
-      "metageneration": "1",
-      "location": "US",
-      "storageClass": "STANDARD",
-      "etag": "CAE=",
-      "timeCreated": "2022-06-07T03:24:28.921Z",
-      "updated": "2022-06-07T03:24:28.921Z",
-      "iamConfiguration": {
-        "bucketPolicyOnly": {
-          "enabled": false
-        },
-        "uniformBucketLevelAccess": {
-          "enabled": false
-        },
-        "publicAccessPrevention": "inherited"
-      },
-      "locationType": "multi-region",
-      "rpo": "DEFAULT"
+CHECK  "staging.test-gcp-scanner.appspot.com": {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/staging.test-gcp-scanner.appspot.com",
+CHECK    "id": "staging.test-gcp-scanner.appspot.com",
+CHECK    "name": "staging.test-gcp-scanner.appspot.com",
+    "projectNumber": "413204024550",
+    "metageneration": "1",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAE=",
+    "timeCreated": "2022-06-07T03:24:29.093Z",
+    "updated": "2022-06-07T03:24:29.093Z",
+    "lifecycle": {
+      "rule": [
+        {
+          "action": {
+            "type": "Delete"
+          },
+          "condition": {
+            "age": 15
+          }
+        }
+      ]
     },
-    null
-  ],
-CHECK  "us.artifacts.test-gcp-scanner.appspot.com": [
-    {
-      "kind": "storage#bucket",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/us.artifacts.test-gcp-scanner.appspot.com",
-CHECK      "id": "us.artifacts.test-gcp-scanner.appspot.com",
-CHECK      "name": "us.artifacts.test-gcp-scanner.appspot.com",
-      "projectNumber": "413204024550",
-      "metageneration": "1",
-      "location": "US",
-      "storageClass": "STANDARD",
-      "etag": "CAE=",
-      "timeCreated": "2022-06-07T03:13:03.199Z",
-      "updated": "2022-06-07T03:13:03.199Z",
-      "iamConfiguration": {
-        "bucketPolicyOnly": {
-          "enabled": false
-        },
-        "uniformBucketLevelAccess": {
-          "enabled": false
-        },
-        "publicAccessPrevention": "inherited"
+    "iamConfiguration": {
+      "bucketPolicyOnly": {
+        "enabled": false
       },
-      "locationType": "multi-region",
-      "rpo": "DEFAULT"
+      "uniformBucketLevelAccess": {
+        "enabled": false
+      },
+      "publicAccessPrevention": "inherited"
     },
-    null
-  ]
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
+  },
+CHECK  "test-gcp-scanner.appspot.com": {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/test-gcp-scanner.appspot.com",
+CHECK    "id": "test-gcp-scanner.appspot.com",
+CHECK    "name": "test-gcp-scanner.appspot.com",
+    "projectNumber": "413204024550",
+    "metageneration": "1",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAE=",
+    "timeCreated": "2022-06-07T03:24:28.921Z",
+    "updated": "2022-06-07T03:24:28.921Z",
+    "iamConfiguration": {
+      "bucketPolicyOnly": {
+        "enabled": false
+      },
+      "uniformBucketLevelAccess": {
+        "enabled": false
+      },
+      "publicAccessPrevention": "inherited"
+    },
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
+  }
+CHECK  "us.artifacts.test-gcp-scanner.appspot.com": {
+    "kind": "storage#bucket",
+    "selfLink": "https://www.googleapis.com/storage/v1/b/us.artifacts.test-gcp-scanner.appspot.com",
+CHECK    "id": "us.artifacts.test-gcp-scanner.appspot.com",
+CHECK    "name": "us.artifacts.test-gcp-scanner.appspot.com",
+    "projectNumber": "413204024550",
+    "metageneration": "1",
+    "location": "US",
+    "storageClass": "STANDARD",
+    "etag": "CAE=",
+    "timeCreated": "2022-06-07T03:13:03.199Z",
+    "updated": "2022-06-07T03:13:03.199Z",
+    "iamConfiguration": {
+      "bucketPolicyOnly": {
+        "enabled": false
+      },
+      "uniformBucketLevelAccess": {
+        "enabled": false
+      },
+      "publicAccessPrevention": "inherited"
+    },
+    "locationType": "multi-region",
+    "rpo": "DEFAULT"
+  }
 }


### PR DESCRIPTION
## Description

We use a predefined schema to select the most interesting fields for printing. User can enable it with -ls flag.

## Changes Made
* added new function to save results
* Requests are now timed out by 120 seconds
* Impersonation is now disabled by default
* Unwrapped several unnecessary lists in responses
* Fixes extra null output in GCS scanning results

## Related Issues
#135