### PR TITLE
fix: handle bad keyfiles

### DIFF
--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -497,7 +497,8 @@ def get_sa_details_from_key_files(key_path):
       malformed_keys.append(keyfile)
 
   if len(malformed_keys) > 0:
-    logging.error('Failed to parse keyfile(s): ', malformed_keys)
+    for malformed_key in malformed_keys:
+      logging.error('Failed to parse keyfile: %s', malformed_key)
 
   return sa_details
 


### PR DESCRIPTION
closes #141 
- moved the logic of fetching sa_credentials to a method
- handled exception while fetching sa_credentials from keyfiles
- added error log for all the malformed keyfiles