### PR TITLE
:recycle: refactor scanner.py to reduce repetative if statements.

### DIFF
--- a/src/gcp_scanner/crawl.py
+++ b/src/gcp_scanner/crawl.py
@@ -16,8 +16,6 @@
 """The module to query GCP resources via RestAPI.
 
 """
-
-import collections
 import logging
 import sys
 from typing import List, Dict, Any, Tuple
@@ -25,15 +23,6 @@ from typing import List, Dict, Any, Tuple
 from google.cloud import container_v1
 import requests
 from requests.auth import HTTPBasicAuth
-
-
-def infinite_defaultdict():
-  """Initialize infinite default.
-
-  Returns:
-    DefaultDict
-  """
-  return collections.defaultdict(infinite_defaultdict)
 
 
 def get_gke_clusters(

--- a/src/gcp_scanner/crawl.py
+++ b/src/gcp_scanner/crawl.py
@@ -93,28 +93,3 @@ def get_gke_images(project_name: str, access_token: str) -> Dict[str, Any]:
       logging.info(sys.exc_info())
 
   return images
-
-
-def get_sas_for_impersonation(
-  iam_policy: List[Dict[str, Any]]) -> List[str]:
-  """Extract a list of unique SAs from IAM policy associated with project.
-
-  Args:
-    iam_policy: An IAM policy provided by get_iam_policy function.
-
-  Returns:
-    A list of service accounts represented as string
-  """
-
-  if not iam_policy:
-    return []
-
-  list_of_sas = list()
-  for entry in iam_policy:
-    for sa_name in entry.get("members", []):
-      if sa_name.startswith("serviceAccount") and "@" in sa_name:
-        account_name = sa_name.split(":")[1]
-        if account_name not in list_of_sas:
-          list_of_sas.append(account_name)
-
-  return list_of_sas

--- a/src/gcp_scanner/crawler/app_services_crawler.py
+++ b/src/gcp_scanner/crawler/app_services_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class AppServicesCrawler(ICrawler):
   '''Handle crawling of App Services data.'''
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> Dict[str, Any]:
     '''Retrieve a list of AppEngine instances available in the project.
 
     Args:
       project_name: A name of a project to query info about.
       service: A resource object for interacting with the AppEngine API.
+      config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.
@@ -42,8 +44,8 @@ class AppServicesCrawler(ICrawler):
       response = request.execute()
       if response.get("name", None) is not None:
         app_services["default_app"] = (response["name"],
-                                      response["defaultHostname"],
-                                      response["servingStatus"])
+                                       response["defaultHostname"],
+                                       response["servingStatus"])
 
       request = service.apps().services().list(appsId=project_name)
 
@@ -52,7 +54,7 @@ class AppServicesCrawler(ICrawler):
         response = request.execute()
         app_services["services"] = response.get("services", [])
         request = service.apps().services().list_next(
-            previous_request=request, previous_response=response)
+          previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to retrieve App services for project %s", project_name)
       logging.info(sys.exc_info())

--- a/src/gcp_scanner/crawler/bigtable_instances_crawler.py
+++ b/src/gcp_scanner/crawler/bigtable_instances_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class BigTableInstancesCrawler(ICrawler):
   '''Handle crawling of BigTable Instances data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_id: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of BigTable instances available in the project.
 
     Args:
       project_id: A name of a project to query info about.
       service: A resource object for interacting with the BigTable API.
+      config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.
@@ -39,14 +41,14 @@ class BigTableInstancesCrawler(ICrawler):
     bigtable_instances_list = list()
     try:
       request = service.projects().instances().list(
-          parent=f"projects/{project_id}")
+        parent=f"projects/{project_id}")
       while request is not None:
         response = request.execute()
         bigtable_instances_list = response.get("instances", [])
         request = service.projects().instances().list_next(
-            previous_request=request, previous_response=response)
+          previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to retrieve BigTable instances for project %s",
-                  project_id)
+                   project_id)
       logging.info(sys.exc_info())
     return bigtable_instances_list

--- a/src/gcp_scanner/crawler/cloud_functions_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_functions_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudFunctionsCrawler(ICrawler):
   '''Handle crawling of Cloud Functions data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
+  def crawl(self, project_id: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> Dict[str, Any]:
     '''Retrieve a list of Cloud Functions available in the project.
 
   Args:
     project_id: A name of a project to query info about.
     service: A resource object for interacting with the Cloud Functions API.
+    config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.
@@ -39,12 +41,12 @@ class CloudFunctionsCrawler(ICrawler):
     functions_list = list()
     try:
       request = service.projects().locations().functions().list(
-          parent=f"projects/{project_id}/locations/-")
+        parent=f"projects/{project_id}/locations/-")
       while request is not None:
         response = request.execute()
         functions_list = response.get("functions", [])
         request = service.projects().locations().functions().list_next(
-            previous_request=request, previous_response=response)
+          previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to retrieve CloudFunctions for project %s", project_id)
       logging.info(sys.exc_info())

--- a/src/gcp_scanner/crawler/cloud_resource_manager_iam_policy_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_iam_policy_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudResourceManagerIAMPolicyCrawler(ICrawler):
   '''Handle crawling of Cloud Resource Manager IAM Policy data.'''
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     '''Retrieve an IAM Policy in the project.
 
     Args:
       project_name: A name of a project to query info about.
       service: A resource object for interacting with the cloud source API.
+      config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.
@@ -42,7 +44,7 @@ class CloudResourceManagerIAMPolicyCrawler(ICrawler):
     get_policy_options = {"options": {"requestedPolicyVersion": 3}}
     try:
       request = service.projects().getIamPolicy(
-          resource=resource, body=get_policy_options)
+        resource=resource, body=get_policy_options)
       response = request.execute()
     except Exception:
       logging.info("Failed to get endpoints list for project %s", project_name)

--- a/src/gcp_scanner/crawler/cloud_resource_manager_project_info_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_project_info_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudResourceManagerProjectInfoCrawler(ICrawler):
   '''Handle crawling of Cloud Resource Manager Project Info data.'''
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> Dict[str, Any]:
     '''Retrieve information about specific project.
 
     Args:
       project_name: Name of project to request info about
       service: A resource object for interacting with the Cloud Source API.
+      config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/compute_disks_crawler.py
+++ b/src/gcp_scanner/crawler/compute_disks_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeDisksCrawler(ICrawler):
   """Handle crawling of compute disks data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of Compute disks available in the project.
 
      Args:
          project_name: The name of the project to query information about.
          service: A resource object for interacting with the GCP API.
+         config: Configuration options for the crawler (Optional).
 
      Returns:
          A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/compute_firewall_rules_crawler.py
+++ b/src/gcp_scanner/crawler/compute_firewall_rules_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeFirewallRulesCrawler(ICrawler):
   """Handle crawling of compute firewall rules data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of firewall rules in the project.
 
      Args:
          project_name: The name of the project to query information about.
          service: A resource object for interacting with the GCP API.
+         config: Configuration options for the crawler (Optional).
 
      Returns:
          A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/compute_images_crawler.py
+++ b/src/gcp_scanner/crawler/compute_images_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeImagesCrawler(ICrawler):
   """Handle crawling of compute images data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of Compute images available in the project.
 
    Args:
        project_name: The name of the project to query information about.
        service: A resource object for interacting with the GCP API.
+       config: Configuration options for the crawler (Optional).
 
    Returns:
        A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/compute_instances_crawler.py
+++ b/src/gcp_scanner/crawler/compute_instances_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeInstancesCrawler(ICrawler):
   """Handle crawling of compute instances data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of Compute VMs available in the project.
 
    Args:
        project_name: The name of the project to query information about.
        service: A resource object for interacting with the GCP API.
+       config: Configuration options for the crawler (Optional).
 
    Returns:
        A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/compute_snapshots_crawler.py
+++ b/src/gcp_scanner/crawler/compute_snapshots_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeSnapshotsCrawler(ICrawler):
   """Handle crawling of compute snapshot data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of Compute snapshots available in the project.
 
     Args:
         project_name: The name of the project to query information about.
         service: A resource object for interacting with the GCP API.
+        config: Configuration options for the crawler (Optional).
 
     Returns:
         A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/compute_static_ips_crawler.py
+++ b/src/gcp_scanner/crawler/compute_static_ips_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeStaticIPsCrawler(ICrawler):
   """Handle crawling of static ips data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of static IPs available in the project.
 
     Args:
         project_name: The name of the project to query information about.
         service: A resource object for interacting with the GCP API.
+        config: Configuration options for the crawler (Optional).
 
     Returns:
         A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/compute_subnets_crawler.py
+++ b/src/gcp_scanner/crawler/compute_subnets_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeSubnetsCrawler(ICrawler):
   """Handle crawling of compute subnets data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of subnets available in the project.
 
      Args:
          project_name: The name of the project to query information about.
          service: A resource object for interacting with the GCP API.
+         config: Configuration options for the crawler (Optional).
 
      Returns:
          A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
+++ b/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class DNSManagedZonesCrawler(ICrawler):
   """Handle crawling of dns managed zones data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of DNS zones available in the project.
 
     Args:
         project_name: The name of the project to query information about.
         service: A resource object for interacting with the GCP API.
+        config: Configuration options for the crawler (Optional).
 
     Returns:
         A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
+++ b/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
@@ -1,16 +1,16 @@
 #  Copyright 2023 Google LLC
 #
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-#       https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 import logging
 import sys
 from typing import List, Dict, Any, Union

--- a/src/gcp_scanner/crawler/dns_policies_crawler.py
+++ b/src/gcp_scanner/crawler/dns_policies_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class DNSPoliciesCrawler(ICrawler):
   """Handle crawling of dns policies data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of cloud DNS policies in the project.
 
     Args:
         project_name: The name of the project to query information about.
         service: A resource object for interacting with the GCP API.
+        config: Configuration options for the crawler (Optional).
 
     Returns:
         A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/endpoints_crawler.py
+++ b/src/gcp_scanner/crawler/endpoints_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class EndpointsCrawler(ICrawler):
   """Handle crawling of endpoints data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of Endpoints available in the project.
 
      Args:
          project_name: The name of the project to query information about.
          service: A resource object for interacting with the GCP API.
+         config: Configuration options for the crawler (Optional).
 
      Returns:
          A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/filestore_instances_crawler.py
+++ b/src/gcp_scanner/crawler/filestore_instances_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class FilestoreInstancesCrawler(ICrawler):
   '''Handle crawling of Filestore Instances data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_id: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     '''Retrieve a list of Filestore instances available in the project.
 
     Args:
       project_id: A name of a project to query info about.
       service: A resource object for interacting with the File Store API.
+      config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.
@@ -39,13 +41,13 @@ class FilestoreInstancesCrawler(ICrawler):
     filestore_instances_list = list()
     try:
       request = service.projects().locations().instances().list(
-          parent=f"projects/{project_id}/locations/-")
+        parent=f"projects/{project_id}/locations/-")
       while request is not None:
         response = request.execute()
         filestore_instances_list = response.get("instances", [])
         request = service.projects().locations().instances().list_next(
-            previous_request=request, previous_response=response)
+          previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to get filestore instances for project %s", project_id)
       logging.info(sys.exc_info())
-    return filestore_instances_list   
+    return filestore_instances_list

--- a/src/gcp_scanner/crawler/machine_images_crawler.py
+++ b/src/gcp_scanner/crawler/machine_images_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeMachineImagesCrawler(ICrawler):
   """Handle crawling of machine images data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of Machine Images Resources available in the project.
 
    Args:
        project_name: The name of the project to query information about.
        service: A resource object for interacting with the GCP API.
+       config: Configuration options for the crawler (Optional).
 
    Returns:
        A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/misc_crawler.py
+++ b/src/gcp_scanner/crawler/misc_crawler.py
@@ -1,16 +1,16 @@
 #  Copyright 2023 Google LLC
 #
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-#       https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 import logging
 import sys
 from typing import List, Dict, Any, Tuple

--- a/src/gcp_scanner/crawler/misc_crawler.py
+++ b/src/gcp_scanner/crawler/misc_crawler.py
@@ -1,27 +1,22 @@
-# Copyright 2022 Google LLC
+#  Copyright 2023 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#       https://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-
-"""The module to query GCP resources via RestAPI.
-
-"""
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 import logging
 import sys
 from typing import List, Dict, Any, Tuple
 
-from google.cloud import container_v1
 import requests
+from google.cloud import container_v1
 from requests.auth import HTTPBasicAuth
 
 

--- a/src/gcp_scanner/crawler/misc_crawler.py
+++ b/src/gcp_scanner/crawler/misc_crawler.py
@@ -11,6 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+"""
+This module provides miscellaneous crawler methods to crawl GCP resources using REST API
+"""
 import logging
 import sys
 from typing import List, Dict, Any, Tuple

--- a/src/gcp_scanner/crawler/pubsub_subscriptions_crawler.py
+++ b/src/gcp_scanner/crawler/pubsub_subscriptions_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class PubSubSubscriptionsCrawler(ICrawler):
   '''Handle crawling of PubSub Subscriptions data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
+  def crawl(self, project_id: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> Dict[str, Any]:
     '''Retrieve a list of PubSub subscriptions available in the project.
 
     Args:
       project_id: A name of a project to query info about.
       service: A resource object for interacting with the PubSub API.
+      config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.
@@ -40,12 +42,12 @@ class PubSubSubscriptionsCrawler(ICrawler):
     try:
 
       request = service.projects().subscriptions().list(
-          project=f"projects/{project_id}")
+        project=f"projects/{project_id}")
       while request is not None:
         response = request.execute()
         pubsubs_list = response.get("subscriptions", [])
         request = service.projects().subscriptions().list_next(
-            previous_request=request, previous_response=response)
+          previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to get PubSubs for project %s", project_id)
       logging.info(sys.exc_info())

--- a/src/gcp_scanner/crawler/service_accounts_crawler.py
+++ b/src/gcp_scanner/crawler/service_accounts_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ServiceAccountsCrawler(ICrawler):
   """Handle crawling of service accounts data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of service accounts in the project.
 
     Args:
         project_name: The name of the project to query information about.
         service: A resource object for interacting with the GCP API.
+        config: Configuration options for the crawler (Optional).
 
     Returns:
         A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/service_usage_crawler.py
+++ b/src/gcp_scanner/crawler/service_usage_crawler.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -23,12 +23,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ServiceUsageCrawler(ICrawler):
   """Handle crawling of service usage data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> List[Dict[str, Any]]:
     """Retrieve a list of services enabled in the project.
 
      Args:
          project_name: The name of the project to query information about.
          service: A resource object for interacting with the GCP API.
+         config: Configuration options for the crawler (Optional).
 
      Returns:
          A list of resource objects representing the crawled data.

--- a/src/gcp_scanner/crawler/source_repo_crawler.py
+++ b/src/gcp_scanner/crawler/source_repo_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudSourceRepoCrawler(ICrawler):
   '''Handle crawling of Cloud Source Repo data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
+  def crawl(self, project_id: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> Dict[str, Any]:
     """Retrieve a list of cloud source repositories enabled in the project.
 
     Args:
     project_id: An id of a project to query info about.
     service: A resource object for interacting with the Source Repo API.
+    config: Configuration options for the crawler (Optional).
 
     Returns:
     A list of cloud source repositories in the project.
@@ -39,19 +41,19 @@ class CloudSourceRepoCrawler(ICrawler):
     list_of_repos = list()
 
     request = service.projects().repos().list(
-        name="projects/" + project_id,
-        pageSize=500
-  )
+      name="projects/" + project_id,
+      pageSize=500
+    )
     try:
-        while request is not None:
-            response = request.execute()
-            list_of_repos.extend(response.get("repos", None))
+      while request is not None:
+        response = request.execute()
+        list_of_repos.extend(response.get("repos", None))
 
-            request = service.projects().repos().list_next(
-            previous_request=request,
-            previous_response=response
-      )
+        request = service.projects().repos().list_next(
+          previous_request=request,
+          previous_response=response
+        )
     except Exception:
-        logging.info("Failed to retrieve source repos for project %s", project_id)
-        logging.info(sys.exc_info())
+      logging.info("Failed to retrieve source repos for project %s", project_id)
+      logging.info(sys.exc_info())
     return list_of_repos

--- a/src/gcp_scanner/crawler/spanner_instances_crawler.py
+++ b/src/gcp_scanner/crawler/spanner_instances_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class SpannerInstancesCrawler(ICrawler):
   '''Handle crawling of Spanner Instances data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
+  def crawl(self, project_id: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> Dict[str, Any]:
     '''Retrieve a list of Spanner instances available in the project.
 
     Args:
       project_id: A name of a project to query info about.
       service: A resource object for interacting with the Spanner API.
+      config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.
@@ -39,14 +41,14 @@ class SpannerInstancesCrawler(ICrawler):
     spanner_instances_list = list()
     try:
       request = service.projects().instances().list(
-          parent=f"projects/{project_id}")
+        parent=f"projects/{project_id}")
       while request is not None:
         response = request.execute()
         spanner_instances_list = response.get("instances", [])
         request = service.projects().instances().list_next(
-            previous_request=request, previous_response=response)
+          previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to retrieve Spanner instances for project %s",
-                  project_id)
+                   project_id)
       logging.info(sys.exc_info())
     return spanner_instances_list

--- a/src/gcp_scanner/crawler/sql_instances_crawler.py
+++ b/src/gcp_scanner/crawler/sql_instances_crawler.py
@@ -14,7 +14,7 @@
 
 import logging
 import sys
-from typing import List, Dict, Any
+from typing import Dict, Any, Union
 
 from googleapiclient import discovery
 
@@ -24,12 +24,14 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class SQLInstancesCrawler(ICrawler):
   '''Handle crawling of SQL Instances data.'''
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
+  def crawl(self, project_name: str, service: discovery.Resource,
+            config: Dict[str, Union[bool, str]] = None) -> Dict[str, Any]:
     '''Retrieve a list of SQL instances available in the project.
 
     Args:
       project_name: A name of a project to query info about.
       service: A resource object for interacting with the SQLAdmin API.
+      config: Configuration options for the crawler (Optional).
 
     Returns:
       A list of resource objects representing the crawled data.
@@ -43,7 +45,7 @@ class SQLInstancesCrawler(ICrawler):
         response = request.execute()
         sql_instances_list = response.get("items", [])
         request = service.instances().list_next(
-            previous_request=request, previous_response=response)
+          previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to get SQL instances for project %s", project_name)
       logging.info(sys.exc_info())

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -69,6 +69,7 @@ crawl_client_map = {
   'compute_instances': 'compute',
   'compute_snapshots': 'compute',
   'dns_policies': 'dns',
+  'endpoints': 'servicemanagement',
   'filestore_instances': 'file',
   'firewall_rules': 'compute',
   'iam_policy': 'cloudresourcemanager',
@@ -76,9 +77,9 @@ crawl_client_map = {
   'machine_images': 'compute',
   'managed_zones': 'dns',
   'project_info': 'cloudresourcemanager',
-  # 'project_list': 'cloudresourcemanager',
   'pubsub_subs': 'pubsub',
   'services': 'serviceusage',
+  'service_accounts': 'iam',
   'sourcerepos': 'sourcerepo',
   'spanner_instances': 'spanner',
   'sql_instances': 'sqladmin',
@@ -220,18 +221,6 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
             ClientFactory.get_client(client_name).get_service(credentials),
           )
 
-      if is_set(scan_config, 'service_accounts'):
-        # Get service accounts
-        project_service_accounts = CrawlerFactory.create_crawler(
-          'service_accounts',
-        ).crawl(
-          project_number,
-          ClientFactory.get_client('iam').get_service(
-            credentials,
-          ),
-        )
-        project_result['service_accounts'] = project_service_accounts
-
       # Iterate over discovered service accounts by attempting impersonation
       project_result['service_account_edges'] = []
       updated_chain = chain_so_far + [sa_name]
@@ -265,17 +254,6 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
       if is_set(scan_config, 'gke_images'):
         project_result['gke_images'] = crawl.get_gke_images(project_id,
                                                             credentials.token)
-
-      # Get information about Endpoints
-      if is_set(scan_config, 'endpoints'):
-        project_result['endpoints'] = CrawlerFactory.create_crawler(
-          'endpoints',
-        ).crawl(
-          project_id,
-          ClientFactory.get_client('servicemanagement').get_service(
-            credentials,
-          ),
-        )
 
       if scan_config is not None:
         impers = scan_config.get('service_accounts', None)

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -193,7 +193,6 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
         continue
 
       project_id = project['projectId']
-      project_number = project['projectNumber']
       print(f'Inspecting project {project_id}')
       project_result = sa_results['projects'][project_id]
 

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -234,11 +234,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
             crawler_config,
           )
 
-      # Iterate over discovered service accounts by attempting impersonation
-      project_result['service_account_edges'] = []
-      updated_chain = chain_so_far + [sa_name]
-
-      # Get GKE resources
+      # Call other miscellaneous crawlers here
       if is_set(scan_config, 'gke_clusters'):
         gke_client = gke_client_for_credentials(credentials)
         project_result['gke_clusters'] = misc_crawler.get_gke_clusters(
@@ -250,6 +246,10 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
           project_id,
           credentials.token,
         )
+
+      # Iterate over discovered service accounts by attempting impersonation
+      project_result['service_account_edges'] = []
+      updated_chain = chain_so_far + [sa_name]
 
       if scan_config is not None:
         impers = scan_config.get('service_accounts', None)

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -34,9 +34,9 @@ from googleapiclient import discovery
 from httplib2 import Credentials
 
 from . import arguments
-from . import crawl
 from . import credsdb
 from .client.client_factory import ClientFactory
+from .crawler import misc_crawler
 from .crawler.crawler_factory import CrawlerFactory
 from .models import SpiderContext
 
@@ -238,11 +238,15 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
       # Get GKE resources
       if is_set(scan_config, 'gke_clusters'):
         gke_client = gke_client_for_credentials(credentials)
-        project_result['gke_clusters'] = crawl.get_gke_clusters(project_id,
-                                                                gke_client)
+        project_result['gke_clusters'] = misc_crawler.get_gke_clusters(
+          project_id,
+          gke_client,
+        )
       if is_set(scan_config, 'gke_images'):
-        project_result['gke_images'] = crawl.get_gke_images(project_id,
-                                                            credentials.token)
+        project_result['gke_images'] = misc_crawler.get_gke_images(
+          project_id,
+          credentials.token,
+        )
 
       if scan_config is not None:
         impers = scan_config.get('service_accounts', None)

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -213,7 +213,9 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       for crawler_name, client_name in crawl_client_map.items():
         if is_set(scan_config, crawler_name):
-          project_result[crawler_name] = CrawlerFactory.create_crawler(crawler_name).crawl(
+          project_result[crawler_name] = CrawlerFactory.create_crawler(
+            crawler_name
+          ).crawl(
             project_id,
             ClientFactory.get_client(client_name).get_service(credentials),
           )

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -16,7 +16,7 @@
 """The main module that initiates scanning of GCP resources.
 
 """
-
+import collections
 import json
 import logging
 import os
@@ -156,7 +156,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
     # Don't process this service account again
     processed_sas.add(sa_name)
     logging.info('>> current service account: %s', sa_name)
-    sa_results = crawl.infinite_defaultdict()
+    sa_results = infinite_defaultdict()
     # Log the chain we used to get here (even if we have no privs)
     sa_results['service_account_chain'] = chain_so_far
     sa_results['current_service_account'] = sa_name
@@ -351,6 +351,15 @@ def get_sas_for_impersonation(
           list_of_sas.append(account_name)
 
   return list_of_sas
+
+
+def infinite_defaultdict():
+  """Initialize infinite default.
+
+  Returns:
+    DefaultDict
+  """
+  return collections.defaultdict(infinite_defaultdict)
 
 
 def main():

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -59,6 +59,9 @@ light_version_scan_schema = {
   'services': ['name'],
 }
 
+# The following map is used to establish the relationship between
+# crawlers and clients. It determines the appropriate crawler and
+# client to be selected from the respective factory classes.
 crawl_client_map = {
   'app_services': 'appengine',
   'bigtable_instances': 'bigtableadmin',

--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -31,7 +31,6 @@ from unittest.mock import patch, Mock
 import requests
 from google.oauth2 import credentials
 
-from . import crawl
 from . import credsdb
 from . import scanner
 from .client.appengine_client import AppEngineClient
@@ -52,6 +51,7 @@ from .client.sourcerepo_client import SourceRepoClient
 from .client.spanner_client import SpannerClient
 from .client.sql_client import SQLClient
 from .client.storage_client import StorageClient
+from .crawler import misc_crawler
 from .crawler.app_services_crawler import AppServicesCrawler
 from .crawler.bigquery_crawler import BigQueryCrawler
 from .crawler.bigtable_instances_crawler import BigTableInstancesCrawler
@@ -535,7 +535,7 @@ class TestCrawler(unittest.TestCase):
     )
     self.assertTrue(
       verify(
-        crawl.get_gke_clusters(PROJECT_NAME, gke_client),
+        misc_crawler.get_gke_clusters(PROJECT_NAME, gke_client),
         "gke_clusters",
       )
     )
@@ -543,7 +543,7 @@ class TestCrawler(unittest.TestCase):
   def test_gke_images(self):
     self.assertTrue(
       verify(
-        crawl.get_gke_images(PROJECT_NAME, self.credentials.token),
+        misc_crawler.get_gke_images(PROJECT_NAME, self.credentials.token),
         "gke_images",
         True,
       )


### PR DESCRIPTION
closes #227 
related to #153 

I've created this PR to improve the way we express the idea. Most of the crawlers have already been implemented, but we still have a few more to go, specifically #229, #230, and #231.

However, we won't be able to completely remove the old crawl.py just yet. We need to have a discussion about the following points:

- Where should we put the remaining pieces of code from `crawl.py`?
- We couldn't include the **storage_bucket** and **gke** related crawler in the double loop method. Any ideas on how to handle that?
- the signature of the `project_list` crawler does not match with the interface, how to refactor this? 
Also, let's brainstorm ways to polish and enhance this draft.

mentions: @mshudrak @0xDeva @peb-peb and others.