### PR TITLE
feat ✨: make the scan loop asynchronous

### DIFF
--- a/src/gcp_scanner/crawler/app_services_crawler.py
+++ b/src/gcp_scanner/crawler/app_services_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class AppServicesCrawler(ICrawler):
   '''Handle crawling of App Services data.'''
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
     '''Retrieve a list of AppEngine instances available in the project.
 
     Args:
@@ -39,7 +39,7 @@ class AppServicesCrawler(ICrawler):
     app_services = dict()
     try:
       request = service.apps().get(appsId=project_name)
-      response = request.execute()
+      response = await request.execute()
       if response.get("name", None) is not None:
         app_services["default_app"] = (response["name"],
                                       response["defaultHostname"],

--- a/src/gcp_scanner/crawler/app_services_crawler.py
+++ b/src/gcp_scanner/crawler/app_services_crawler.py
@@ -39,7 +39,7 @@ class AppServicesCrawler(ICrawler):
     app_services = dict()
     try:
       request = service.apps().get(appsId=project_name)
-      response = await request.execute()
+      response = request.execute()
       if response.get("name", None) is not None:
         app_services["default_app"] = (response["name"],
                                       response["defaultHostname"],
@@ -56,4 +56,5 @@ class AppServicesCrawler(ICrawler):
     except Exception:
       logging.info("Failed to retrieve App services for project %s", project_name)
       logging.info(sys.exc_info())
+    logging.info("Exiting app services")
     return app_services

--- a/src/gcp_scanner/crawler/bigquery_crawler.py
+++ b/src/gcp_scanner/crawler/bigquery_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class BigQueryCrawler(ICrawler):
   '''Handle crawling of BigQuery data.'''
 
-  def crawl(self, project_id: str,
+  async def crawl(self, project_id: str,
                   service: discovery.Resource) -> Dict[str, List[Dict[str, Any]]]:
     '''Retrieve a list of BigQuery datasets available in the project.
 
@@ -41,7 +41,7 @@ class BigQueryCrawler(ICrawler):
     try:
       request = service.datasets().list(projectId=project_id)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
 
         for dataset in response.get("datasets", []):
           dataset_id = dataset["datasetReference"]["datasetId"]

--- a/src/gcp_scanner/crawler/bigquery_crawler.py
+++ b/src/gcp_scanner/crawler/bigquery_crawler.py
@@ -41,7 +41,7 @@ class BigQueryCrawler(ICrawler):
     try:
       request = service.datasets().list(projectId=project_id)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
 
         for dataset in response.get("datasets", []):
           dataset_id = dataset["datasetReference"]["datasetId"]
@@ -52,6 +52,7 @@ class BigQueryCrawler(ICrawler):
     except Exception:
       logging.info("Failed to retrieve BQ datasets for project %s", project_id)
       logging.info(sys.exc_info())
+    logging.info("Exiting BigQuery Datasets")
     return bq_datasets
 
 

--- a/src/gcp_scanner/crawler/bigtable_instances_crawler.py
+++ b/src/gcp_scanner/crawler/bigtable_instances_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class BigTableInstancesCrawler(ICrawler):
   '''Handle crawling of BigTable Instances data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_id: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of BigTable instances available in the project.
 
     Args:
@@ -41,7 +41,7 @@ class BigTableInstancesCrawler(ICrawler):
       request = service.projects().instances().list(
           parent=f"projects/{project_id}")
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         bigtable_instances_list = response.get("instances", [])
         request = service.projects().instances().list_next(
             previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/bigtable_instances_crawler.py
+++ b/src/gcp_scanner/crawler/bigtable_instances_crawler.py
@@ -41,7 +41,7 @@ class BigTableInstancesCrawler(ICrawler):
       request = service.projects().instances().list(
           parent=f"projects/{project_id}")
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         bigtable_instances_list = response.get("instances", [])
         request = service.projects().instances().list_next(
             previous_request=request, previous_response=response)
@@ -49,4 +49,5 @@ class BigTableInstancesCrawler(ICrawler):
       logging.info("Failed to retrieve BigTable instances for project %s",
                   project_id)
       logging.info(sys.exc_info())
+    logging.info("Exiting bigtable instances")
     return bigtable_instances_list

--- a/src/gcp_scanner/crawler/cloud_functions_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_functions_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudFunctionsCrawler(ICrawler):
   '''Handle crawling of Cloud Functions data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
+  async def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
     '''Retrieve a list of Cloud Functions available in the project.
 
   Args:
@@ -41,7 +41,7 @@ class CloudFunctionsCrawler(ICrawler):
       request = service.projects().locations().functions().list(
           parent=f"projects/{project_id}/locations/-")
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         functions_list = response.get("functions", [])
         request = service.projects().locations().functions().list_next(
             previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/cloud_functions_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_functions_crawler.py
@@ -41,12 +41,12 @@ class CloudFunctionsCrawler(ICrawler):
       request = service.projects().locations().functions().list(
           parent=f"projects/{project_id}/locations/-")
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         functions_list = response.get("functions", [])
         request = service.projects().locations().functions().list_next(
             previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to retrieve CloudFunctions for project %s", project_id)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting CloudFunctions")
     return functions_list

--- a/src/gcp_scanner/crawler/cloud_resource_manager_iam_policy_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_iam_policy_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudResourceManagerIAMPolicyCrawler(ICrawler):
   '''Handle crawling of Cloud Resource Manager IAM Policy data.'''
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     '''Retrieve an IAM Policy in the project.
 
     Args:
@@ -43,7 +43,7 @@ class CloudResourceManagerIAMPolicyCrawler(ICrawler):
     try:
       request = service.projects().getIamPolicy(
           resource=resource, body=get_policy_options)
-      response = request.execute()
+      response = await request.execute()
     except Exception:
       logging.info("Failed to get endpoints list for project %s", project_name)
       logging.info(sys.exc_info())

--- a/src/gcp_scanner/crawler/cloud_resource_manager_iam_policy_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_iam_policy_crawler.py
@@ -43,7 +43,7 @@ class CloudResourceManagerIAMPolicyCrawler(ICrawler):
     try:
       request = service.projects().getIamPolicy(
           resource=resource, body=get_policy_options)
-      response = await request.execute()
+      response = request.execute()
     except Exception:
       logging.info("Failed to get endpoints list for project %s", project_name)
       logging.info(sys.exc_info())

--- a/src/gcp_scanner/crawler/cloud_resource_manager_project_info_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_project_info_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudResourceManagerProjectInfoCrawler(ICrawler):
   '''Handle crawling of Cloud Resource Manager Project Info data.'''
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
     '''Retrieve information about specific project.
 
     Args:
@@ -40,7 +40,7 @@ class CloudResourceManagerProjectInfoCrawler(ICrawler):
 
     try:
       request = service.projects().get(projectId=project_name)
-      response = request.execute()
+      response = await request.execute()
       if "projectNumber" in response:
         project_info = response
 

--- a/src/gcp_scanner/crawler/cloud_resource_manager_project_info_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_project_info_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudResourceManagerProjectInfoCrawler(ICrawler):
   '''Handle crawling of Cloud Resource Manager Project Info data.'''
 
-  async def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
+  def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
     '''Retrieve information about specific project.
 
     Args:
@@ -40,12 +40,12 @@ class CloudResourceManagerProjectInfoCrawler(ICrawler):
 
     try:
       request = service.projects().get(projectId=project_name)
-      response = await request.execute()
+      response = request.execute()
       if "projectNumber" in response:
         project_info = response
 
     except Exception:
       logging.info("Failed to enumerate projects")
       logging.info(sys.exc_info())
-
+    logging.info("Exiting info about: %s", project_name)
     return project_info

--- a/src/gcp_scanner/crawler/cloud_resource_manager_project_list_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_project_list_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudResourceManagerProjectListCrawler(ICrawler):
   '''Handle crawling of Cloud Resource Manager Project List data.'''
 
-  async def crawl(self, service: discovery.Resource) -> List[Dict[str, Any]]:
+  def crawl(self, service: discovery.Resource) -> List[Dict[str, Any]]:
     '''Retrieve a list of projects accessible by credentials provided.
 
     Args:
@@ -39,11 +39,12 @@ class CloudResourceManagerProjectListCrawler(ICrawler):
     try:
       request = service.projects().list()
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         project_list = response.get("projects",[])
         request = service.projects().list_next(
             previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to enumerate projects")
       logging.info(sys.exc_info())
+    logging.info("Exiting projects list")
     return project_list

--- a/src/gcp_scanner/crawler/cloud_resource_manager_project_list_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_project_list_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudResourceManagerProjectListCrawler(ICrawler):
   '''Handle crawling of Cloud Resource Manager Project List data.'''
 
-  def crawl(self, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, service: discovery.Resource) -> List[Dict[str, Any]]:
     '''Retrieve a list of projects accessible by credentials provided.
 
     Args:
@@ -39,7 +39,7 @@ class CloudResourceManagerProjectListCrawler(ICrawler):
     try:
       request = service.projects().list()
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         project_list = response.get("projects",[])
         request = service.projects().list_next(
             previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/compute_disks_crawler.py
+++ b/src/gcp_scanner/crawler/compute_disks_crawler.py
@@ -38,7 +38,7 @@ class ComputeDisksCrawler(ICrawler):
     try:
       request = service.disks().aggregatedList(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         if response.get("items", None) is not None:
           disk_names_list = [
             disk for _, disks_scoped_list in response["items"].items()
@@ -49,5 +49,5 @@ class ComputeDisksCrawler(ICrawler):
     except Exception:
       logging.info("Failed to enumerate compute disks in the %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting list of Compute Disk names")
     return disk_names_list

--- a/src/gcp_scanner/crawler/compute_disks_crawler.py
+++ b/src/gcp_scanner/crawler/compute_disks_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeDisksCrawler(ICrawler):
   """Handle crawling of compute disks data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of Compute disks available in the project.
 
      Args:
@@ -38,7 +38,7 @@ class ComputeDisksCrawler(ICrawler):
     try:
       request = service.disks().aggregatedList(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         if response.get("items", None) is not None:
           disk_names_list = [
             disk for _, disks_scoped_list in response["items"].items()

--- a/src/gcp_scanner/crawler/compute_firewall_rules_crawler.py
+++ b/src/gcp_scanner/crawler/compute_firewall_rules_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeFirewallRulesCrawler(ICrawler):
   """Handle crawling of compute firewall rules data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of firewall rules in the project.
 
      Args:
@@ -38,7 +38,7 @@ class ComputeFirewallRulesCrawler(ICrawler):
     try:
       request = service.firewalls().list(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         firewall_rules_list = [(firewall["name"],)
                                for firewall in response.get("items", [])]
         request = service.firewalls().list_next(

--- a/src/gcp_scanner/crawler/compute_firewall_rules_crawler.py
+++ b/src/gcp_scanner/crawler/compute_firewall_rules_crawler.py
@@ -38,7 +38,7 @@ class ComputeFirewallRulesCrawler(ICrawler):
     try:
       request = service.firewalls().list(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         firewall_rules_list = [(firewall["name"],)
                                for firewall in response.get("items", [])]
         request = service.firewalls().list_next(
@@ -46,4 +46,5 @@ class ComputeFirewallRulesCrawler(ICrawler):
     except Exception:
       logging.info("Failed to get firewall rules in the %s", project_name)
       logging.info(sys.exc_info())
+    logging.info("Exiting Firewall Rules")
     return firewall_rules_list

--- a/src/gcp_scanner/crawler/compute_images_crawler.py
+++ b/src/gcp_scanner/crawler/compute_images_crawler.py
@@ -39,11 +39,12 @@ class ComputeImagesCrawler(ICrawler):
     try:
       request = service.images().list(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         images_result = response.get("items", [])
         request = service.images().list_next(
           previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to enumerate compute images in the %s", project_name)
       logging.info(sys.exc_info())
+    logging.info("Exiting list of Compute Image names")
     return images_result

--- a/src/gcp_scanner/crawler/compute_images_crawler.py
+++ b/src/gcp_scanner/crawler/compute_images_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeImagesCrawler(ICrawler):
   """Handle crawling of compute images data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of Compute images available in the project.
 
    Args:
@@ -39,7 +39,7 @@ class ComputeImagesCrawler(ICrawler):
     try:
       request = service.images().list(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         images_result = response.get("items", [])
         request = service.images().list_next(
           previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/compute_instances_crawler.py
+++ b/src/gcp_scanner/crawler/compute_instances_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeInstancesCrawler(ICrawler):
   """Handle crawling of compute instances data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of Compute VMs available in the project.
 
    Args:
@@ -38,7 +38,7 @@ class ComputeInstancesCrawler(ICrawler):
     try:
       request = service.instances().aggregatedList(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         if response.get("items", None) is not None:
           images_result = [instance
                            for _, instances_scoped_list in response["items"].items()

--- a/src/gcp_scanner/crawler/compute_instances_crawler.py
+++ b/src/gcp_scanner/crawler/compute_instances_crawler.py
@@ -38,7 +38,7 @@ class ComputeInstancesCrawler(ICrawler):
     try:
       request = service.instances().aggregatedList(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         if response.get("items", None) is not None:
           images_result = [instance
                            for _, instances_scoped_list in response["items"].items()
@@ -49,4 +49,5 @@ class ComputeInstancesCrawler(ICrawler):
       logging.info("Failed to enumerate compute instances in the %s",
                    project_name)
       logging.info(sys.exc_info())
+    logging.info("Exiting list of Compute Instances")
     return images_result

--- a/src/gcp_scanner/crawler/compute_snapshots_crawler.py
+++ b/src/gcp_scanner/crawler/compute_snapshots_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeSnapshotsCrawler(ICrawler):
   """Handle crawling of compute snapshot data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of Compute snapshots available in the project.
 
     Args:
@@ -40,7 +40,7 @@ class ComputeSnapshotsCrawler(ICrawler):
     try:
       request = service.snapshots().list(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         snapshots_list = response.get("items", [])
         request = service.snapshots().list_next(
           previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/compute_snapshots_crawler.py
+++ b/src/gcp_scanner/crawler/compute_snapshots_crawler.py
@@ -40,12 +40,12 @@ class ComputeSnapshotsCrawler(ICrawler):
     try:
       request = service.snapshots().list(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         snapshots_list = response.get("items", [])
         request = service.snapshots().list_next(
           previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to get compute snapshots in the %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting Compute Snapshots")
     return snapshots_list

--- a/src/gcp_scanner/crawler/compute_static_ips_crawler.py
+++ b/src/gcp_scanner/crawler/compute_static_ips_crawler.py
@@ -39,7 +39,7 @@ class ComputeStaticIPsCrawler(ICrawler):
     try:
       request = service.addresses().aggregatedList(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         ips_list = [{name: addresses_scoped_list}
                     for name, addresses_scoped_list in response["items"].items()
                     if addresses_scoped_list.get("addresses", None) is not None]
@@ -48,5 +48,5 @@ class ComputeStaticIPsCrawler(ICrawler):
     except Exception:
       logging.info("Failed to get static IPs in the %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting Static IPs")
     return ips_list

--- a/src/gcp_scanner/crawler/compute_static_ips_crawler.py
+++ b/src/gcp_scanner/crawler/compute_static_ips_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeStaticIPsCrawler(ICrawler):
   """Handle crawling of static ips data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of static IPs available in the project.
 
     Args:
@@ -39,7 +39,7 @@ class ComputeStaticIPsCrawler(ICrawler):
     try:
       request = service.addresses().aggregatedList(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         ips_list = [{name: addresses_scoped_list}
                     for name, addresses_scoped_list in response["items"].items()
                     if addresses_scoped_list.get("addresses", None) is not None]

--- a/src/gcp_scanner/crawler/compute_subnets_crawler.py
+++ b/src/gcp_scanner/crawler/compute_subnets_crawler.py
@@ -38,7 +38,7 @@ class ComputeSubnetsCrawler(ICrawler):
     try:
       request = service.subnetworks().aggregatedList(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         if response.get("items", None) is not None:
           subnets_list = list(response["items"].items())
         request = service.subnetworks().aggregatedList_next(
@@ -46,5 +46,5 @@ class ComputeSubnetsCrawler(ICrawler):
     except Exception:
       logging.info("Failed to get subnets in the %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting Subnets")
     return subnets_list

--- a/src/gcp_scanner/crawler/compute_subnets_crawler.py
+++ b/src/gcp_scanner/crawler/compute_subnets_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeSubnetsCrawler(ICrawler):
   """Handle crawling of compute subnets data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of subnets available in the project.
 
      Args:
@@ -38,7 +38,7 @@ class ComputeSubnetsCrawler(ICrawler):
     try:
       request = service.subnetworks().aggregatedList(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         if response.get("items", None) is not None:
           subnets_list = list(response["items"].items())
         request = service.subnetworks().aggregatedList_next(

--- a/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
+++ b/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
@@ -39,12 +39,12 @@ class DNSManagedZonesCrawler(ICrawler):
     try:
       request = service.managedZones().list(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         zones_list = response.get("managedZones", [])
         request = service.managedZones().list_next(
           previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to enumerate DNS zones for project %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting DNS Managed Zones")
     return zones_list

--- a/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
+++ b/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class DNSManagedZonesCrawler(ICrawler):
   """Handle crawling of dns managed zones data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of DNS zones available in the project.
 
     Args:
@@ -39,7 +39,7 @@ class DNSManagedZonesCrawler(ICrawler):
     try:
       request = service.managedZones().list(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         zones_list = response.get("managedZones", [])
         request = service.managedZones().list_next(
           previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/dns_policies_crawler.py
+++ b/src/gcp_scanner/crawler/dns_policies_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class DNSPoliciesCrawler(ICrawler):
   """Handle crawling of dns policies data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of cloud DNS policies in the project.
 
     Args:
@@ -42,7 +42,7 @@ class DNSPoliciesCrawler(ICrawler):
     )
     try:
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         list_of_policies.extend(response.get("policies", None))
 
         request = service.policies().list_next(

--- a/src/gcp_scanner/crawler/dns_policies_crawler.py
+++ b/src/gcp_scanner/crawler/dns_policies_crawler.py
@@ -42,7 +42,7 @@ class DNSPoliciesCrawler(ICrawler):
     )
     try:
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         list_of_policies.extend(response.get("policies", None))
 
         request = service.policies().list_next(
@@ -52,5 +52,5 @@ class DNSPoliciesCrawler(ICrawler):
     except Exception:
       logging.info("Failed to retrieve DNS policies for project %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting cloud DNS policies %s", project_name)
     return list_of_policies

--- a/src/gcp_scanner/crawler/endpoints_crawler.py
+++ b/src/gcp_scanner/crawler/endpoints_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class EndpointsCrawler(ICrawler):
   """Handle crawling of endpoints data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of Endpoints available in the project.
 
      Args:
@@ -38,7 +38,7 @@ class EndpointsCrawler(ICrawler):
     try:
       request = service.services().list(producerProjectId=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         endpoints_list = response.get("services", [])
         request = service.services().list_next(
           previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/endpoints_crawler.py
+++ b/src/gcp_scanner/crawler/endpoints_crawler.py
@@ -38,11 +38,12 @@ class EndpointsCrawler(ICrawler):
     try:
       request = service.services().list(producerProjectId=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         endpoints_list = response.get("services", [])
         request = service.services().list_next(
           previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to retrieve endpoints list for project %s", project_name)
       logging.info(sys.exc_info())
+    logging.info("Exiting info about endpoints")
     return endpoints_list

--- a/src/gcp_scanner/crawler/filestore_instances_crawler.py
+++ b/src/gcp_scanner/crawler/filestore_instances_crawler.py
@@ -41,11 +41,12 @@ class FilestoreInstancesCrawler(ICrawler):
       request = service.projects().locations().instances().list(
           parent=f"projects/{project_id}/locations/-")
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         filestore_instances_list = response.get("instances", [])
         request = service.projects().locations().instances().list_next(
             previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to get filestore instances for project %s", project_id)
       logging.info(sys.exc_info())
+    logging.info("Exiting filestore instances")
     return filestore_instances_list   

--- a/src/gcp_scanner/crawler/filestore_instances_crawler.py
+++ b/src/gcp_scanner/crawler/filestore_instances_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class FilestoreInstancesCrawler(ICrawler):
   '''Handle crawling of Filestore Instances data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_id: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     '''Retrieve a list of Filestore instances available in the project.
 
     Args:
@@ -41,7 +41,7 @@ class FilestoreInstancesCrawler(ICrawler):
       request = service.projects().locations().instances().list(
           parent=f"projects/{project_id}/locations/-")
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         filestore_instances_list = response.get("instances", [])
         request = service.projects().locations().instances().list_next(
             previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/kms_keys_crawler.py
+++ b/src/gcp_scanner/crawler/kms_keys_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class KMSKeysCrawler(ICrawler):
   '''Handle crawling of KMS Keys data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_id: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     '''Retrieve a list of KMS Keys available in the project.
 
     Args:
@@ -42,7 +42,7 @@ class KMSKeysCrawler(ICrawler):
       locations_list = list()
       request = service.projects().locations().list(name=f"projects/{project_id}")
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         for location in response.get("locations", []):
           locations_list.append(location["locationId"])
         request = service.projects().locations().list_next(

--- a/src/gcp_scanner/crawler/kms_keys_crawler.py
+++ b/src/gcp_scanner/crawler/kms_keys_crawler.py
@@ -42,7 +42,7 @@ class KMSKeysCrawler(ICrawler):
       locations_list = list()
       request = service.projects().locations().list(name=f"projects/{project_id}")
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         for location in response.get("locations", []):
           locations_list.append(location["locationId"])
         request = service.projects().locations().list_next(
@@ -70,4 +70,5 @@ class KMSKeysCrawler(ICrawler):
     except Exception:
       logging.info("Failed to retrieve KMS keys for project %s", project_id)
       logging.info(sys.exc_info())
+    logging.info("Exiting KMS keys")
     return kms_keys_list

--- a/src/gcp_scanner/crawler/machine_images_crawler.py
+++ b/src/gcp_scanner/crawler/machine_images_crawler.py
@@ -38,7 +38,7 @@ class ComputeMachineImagesCrawler(ICrawler):
     try:
       request = service.machineImages().list(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         machine_images_list = response.get("items", [])
         request = service.machineImages().list_next(
           previous_request=request, previous_response=response
@@ -46,4 +46,5 @@ class ComputeMachineImagesCrawler(ICrawler):
     except Exception:
       logging.info("Failed to enumerate machine images in the %s", project_name)
       logging.info(sys.exc_info())
+    logging.info("Exiting list of Machine Images Resources")
     return machine_images_list

--- a/src/gcp_scanner/crawler/machine_images_crawler.py
+++ b/src/gcp_scanner/crawler/machine_images_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ComputeMachineImagesCrawler(ICrawler):
   """Handle crawling of machine images data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of Machine Images Resources available in the project.
 
    Args:
@@ -38,7 +38,7 @@ class ComputeMachineImagesCrawler(ICrawler):
     try:
       request = service.machineImages().list(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         machine_images_list = response.get("items", [])
         request = service.machineImages().list_next(
           previous_request=request, previous_response=response

--- a/src/gcp_scanner/crawler/pubsub_subscriptions_crawler.py
+++ b/src/gcp_scanner/crawler/pubsub_subscriptions_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class PubSubSubscriptionsCrawler(ICrawler):
   '''Handle crawling of PubSub Subscriptions data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
+  async def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
     '''Retrieve a list of PubSub subscriptions available in the project.
 
     Args:
@@ -42,7 +42,7 @@ class PubSubSubscriptionsCrawler(ICrawler):
       request = service.projects().subscriptions().list(
           project=f"projects/{project_id}")
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         pubsubs_list = response.get("subscriptions", [])
         request = service.projects().subscriptions().list_next(
             previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/pubsub_subscriptions_crawler.py
+++ b/src/gcp_scanner/crawler/pubsub_subscriptions_crawler.py
@@ -42,11 +42,12 @@ class PubSubSubscriptionsCrawler(ICrawler):
       request = service.projects().subscriptions().list(
           project=f"projects/{project_id}")
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         pubsubs_list = response.get("subscriptions", [])
         request = service.projects().subscriptions().list_next(
             previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to get PubSubs for project %s", project_id)
       logging.info(sys.exc_info())
+    logging.info("Exiting PubSub Subscriptions")
     return pubsubs_list

--- a/src/gcp_scanner/crawler/service_accounts_crawler.py
+++ b/src/gcp_scanner/crawler/service_accounts_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ServiceAccountsCrawler(ICrawler):
   """Handle crawling of service accounts data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of service accounts in the project.
 
     Args:
@@ -41,7 +41,7 @@ class ServiceAccountsCrawler(ICrawler):
     try:
       request = service.projects().serviceAccounts().list(name=name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         service_accounts = [(service_account["email"],
                              service_account.get("description", ""))
                             for service_account in response.get("accounts", [])]

--- a/src/gcp_scanner/crawler/service_accounts_crawler.py
+++ b/src/gcp_scanner/crawler/service_accounts_crawler.py
@@ -41,7 +41,7 @@ class ServiceAccountsCrawler(ICrawler):
     try:
       request = service.projects().serviceAccounts().list(name=name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         service_accounts = [(service_account["email"],
                              service_account.get("description", ""))
                             for service_account in response.get("accounts", [])]
@@ -51,5 +51,5 @@ class ServiceAccountsCrawler(ICrawler):
     except Exception:
       logging.info("Failed to retrieve SA list for project %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting SA list %s", project_name)
     return service_accounts

--- a/src/gcp_scanner/crawler/service_usage_crawler.py
+++ b/src/gcp_scanner/crawler/service_usage_crawler.py
@@ -23,7 +23,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class ServiceUsageCrawler(ICrawler):
   """Handle crawling of service usage data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> List[Dict[str, Any]]:
     """Retrieve a list of services enabled in the project.
 
      Args:
@@ -40,7 +40,7 @@ class ServiceUsageCrawler(ICrawler):
       parent="projects/" + project_name, pageSize=200, filter="state:ENABLED")
     try:
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         list_of_services.extend(response.get("services", []))
 
         request = service.services().list_next(

--- a/src/gcp_scanner/crawler/service_usage_crawler.py
+++ b/src/gcp_scanner/crawler/service_usage_crawler.py
@@ -40,7 +40,7 @@ class ServiceUsageCrawler(ICrawler):
       parent="projects/" + project_name, pageSize=200, filter="state:ENABLED")
     try:
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         list_of_services.extend(response.get("services", []))
 
         request = service.services().list_next(
@@ -48,5 +48,5 @@ class ServiceUsageCrawler(ICrawler):
     except Exception:
       logging.info("Failed to retrieve services for project %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting services list %s", project_name)
     return list_of_services

--- a/src/gcp_scanner/crawler/source_repo_crawler.py
+++ b/src/gcp_scanner/crawler/source_repo_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class CloudSourceRepoCrawler(ICrawler):
   '''Handle crawling of Cloud Source Repo data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
+  async def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
     """Retrieve a list of cloud source repositories enabled in the project.
 
     Args:
@@ -44,7 +44,7 @@ class CloudSourceRepoCrawler(ICrawler):
   )
     try:
         while request is not None:
-            response = request.execute()
+            response = await request.execute()
             list_of_repos.extend(response.get("repos", None))
 
             request = service.projects().repos().list_next(

--- a/src/gcp_scanner/crawler/source_repo_crawler.py
+++ b/src/gcp_scanner/crawler/source_repo_crawler.py
@@ -44,7 +44,7 @@ class CloudSourceRepoCrawler(ICrawler):
   )
     try:
         while request is not None:
-            response = await request.execute()
+            response = request.execute()
             list_of_repos.extend(response.get("repos", None))
 
             request = service.projects().repos().list_next(
@@ -54,4 +54,5 @@ class CloudSourceRepoCrawler(ICrawler):
     except Exception:
         logging.info("Failed to retrieve source repos for project %s", project_id)
         logging.info(sys.exc_info())
+    logging.info("Exiting cloud source repositories %s", project_id)
     return list_of_repos

--- a/src/gcp_scanner/crawler/spanner_instances_crawler.py
+++ b/src/gcp_scanner/crawler/spanner_instances_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class SpannerInstancesCrawler(ICrawler):
   '''Handle crawling of Spanner Instances data.'''
 
-  def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
+  async def crawl(self, project_id: str, service: discovery.Resource) -> Dict[str, Any]:
     '''Retrieve a list of Spanner instances available in the project.
 
     Args:
@@ -41,7 +41,7 @@ class SpannerInstancesCrawler(ICrawler):
       request = service.projects().instances().list(
           parent=f"projects/{project_id}")
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         spanner_instances_list = response.get("instances", [])
         request = service.projects().instances().list_next(
             previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/spanner_instances_crawler.py
+++ b/src/gcp_scanner/crawler/spanner_instances_crawler.py
@@ -41,7 +41,7 @@ class SpannerInstancesCrawler(ICrawler):
       request = service.projects().instances().list(
           parent=f"projects/{project_id}")
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         spanner_instances_list = response.get("instances", [])
         request = service.projects().instances().list_next(
             previous_request=request, previous_response=response)
@@ -49,4 +49,5 @@ class SpannerInstancesCrawler(ICrawler):
       logging.info("Failed to retrieve Spanner instances for project %s",
                   project_id)
       logging.info(sys.exc_info())
+    logging.info("Exiting spanner instances")
     return spanner_instances_list

--- a/src/gcp_scanner/crawler/sql_instances_crawler.py
+++ b/src/gcp_scanner/crawler/sql_instances_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class SQLInstancesCrawler(ICrawler):
   '''Handle crawling of SQL Instances data.'''
 
-  def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
+  async def crawl(self, project_name: str, service: discovery.Resource) -> Dict[str, Any]:
     '''Retrieve a list of SQL instances available in the project.
 
     Args:
@@ -40,7 +40,7 @@ class SQLInstancesCrawler(ICrawler):
     try:
       request = service.instances().list(project=project_name)
       while request is not None:
-        response = request.execute()
+        response = await request.execute()
         sql_instances_list = response.get("items", [])
         request = service.instances().list_next(
             previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/sql_instances_crawler.py
+++ b/src/gcp_scanner/crawler/sql_instances_crawler.py
@@ -40,12 +40,12 @@ class SQLInstancesCrawler(ICrawler):
     try:
       request = service.instances().list(project=project_name)
       while request is not None:
-        response = await request.execute()
+        response = request.execute()
         sql_instances_list = response.get("items", [])
         request = service.instances().list_next(
             previous_request=request, previous_response=response)
     except Exception:
       logging.info("Failed to get SQL instances for project %s", project_name)
       logging.info(sys.exc_info())
-
+    logging.info("Exiting CloudSQL Instances")
     return sql_instances_list

--- a/src/gcp_scanner/crawler/storage_buckets_crawler.py
+++ b/src/gcp_scanner/crawler/storage_buckets_crawler.py
@@ -46,7 +46,7 @@ class StorageBucketsCrawler(ICrawler):
     request = service.buckets().list(project=project_name)
     while request is not None:
       try:
-        response = await request.execute()
+        response = request.execute()
       except errors.HttpError:
         logging.info("Failed to list buckets in the %s", project_name)
         logging.info(sys.exc_info())
@@ -76,6 +76,7 @@ class StorageBucketsCrawler(ICrawler):
         previous_request=request, previous_response=response)
     if dump_fd is not None:
       dump_fd.close()
+    logging.info("Exiting GCS Buckets")
     return buckets_dict
 
   @classmethod

--- a/src/gcp_scanner/crawler/storage_buckets_crawler.py
+++ b/src/gcp_scanner/crawler/storage_buckets_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class StorageBucketsCrawler(ICrawler):
   """Handle crawling of bucket names data."""
 
-  def crawl(self, project_name: str, service: discovery.Resource,
+  async def crawl(self, project_name: str, service: discovery.Resource,
             config: Dict[str, Union[bool, str]] = None) -> Dict[str, Tuple[Any, List[Any]]]:
     """Retrieve a list of buckets available in the project.
 
@@ -46,7 +46,7 @@ class StorageBucketsCrawler(ICrawler):
     request = service.buckets().list(project=project_name)
     while request is not None:
       try:
-        response = request.execute()
+        response = await request.execute()
       except errors.HttpError:
         logging.info("Failed to list buckets in the %s", project_name)
         logging.info(sys.exc_info())

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -17,6 +17,7 @@
 
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -97,7 +98,7 @@ def save_results(res_data: Dict, res_path: str, is_light: bool):
     outfile.write(sa_results_data)
 
 
-def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
+async def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
                out_dir: str,
                scan_config: Dict,
                light_scan: bool,
@@ -186,7 +187,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       if is_set(scan_config, 'iam_policy'):
         # Get IAM policy
-        project_result['iam_policy'] = CrawlerFactory.create_crawler(
+        project_result['iam_policy'] = await CrawlerFactory.create_crawler(
           'iam_policy',
         ).crawl(
           project_id,
@@ -197,7 +198,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       if is_set(scan_config, 'service_accounts'):
         # Get service accounts
-        project_service_accounts = CrawlerFactory.create_crawler(
+        project_service_accounts = await CrawlerFactory.create_crawler(
           'service_accounts',
         ).crawl(
           project_number,
@@ -217,56 +218,56 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
       ).get_service(credentials)
 
       if is_set(scan_config, 'compute_instances'):
-        project_result['compute_instances'] = CrawlerFactory.create_crawler(
+        project_result['compute_instances'] = await CrawlerFactory.create_crawler(
           'compute_instances',
         ).crawl(
           project_id,
           compute_service,
         )
       if is_set(scan_config, 'compute_images'):
-        project_result['compute_images'] = CrawlerFactory.create_crawler(
+        project_result['compute_images'] = await CrawlerFactory.create_crawler(
           'compute_images',
         ).crawl(
           project_id,
           compute_service,
         )
       if is_set(scan_config, 'machine_images'):
-        project_result['machine_images'] = CrawlerFactory.create_crawler(
+        project_result['machine_images'] = await CrawlerFactory.create_crawler(
           'machine_images',
         ).crawl(
           project_id,
           compute_service,
         )
       if is_set(scan_config, 'compute_disks'):
-        project_result['compute_disks'] = CrawlerFactory.create_crawler(
+        project_result['compute_disks'] = await CrawlerFactory.create_crawler(
           'compute_disks',
         ).crawl(
           project_id,
           compute_service,
         )
       if is_set(scan_config, 'static_ips'):
-        project_result['static_ips'] = CrawlerFactory.create_crawler(
+        project_result['static_ips'] = await CrawlerFactory.create_crawler(
           'static_ips',
         ).crawl(
           project_id,
           compute_service,
         )
       if is_set(scan_config, 'compute_snapshots'):
-        project_result['compute_snapshots'] = CrawlerFactory.create_crawler(
+        project_result['compute_snapshots'] = await CrawlerFactory.create_crawler(
           'compute_snapshots',
         ).crawl(
           project_id,
           compute_service,
         )
       if is_set(scan_config, 'subnets'):
-        project_result['subnets'] = CrawlerFactory.create_crawler(
+        project_result['subnets'] = await CrawlerFactory.create_crawler(
           'subnets',
         ).crawl(
           project_id,
           compute_service,
         )
       if is_set(scan_config, 'firewall_rules'):
-        project_result['firewall_rules'] = CrawlerFactory.create_crawler(
+        project_result['firewall_rules'] = await CrawlerFactory.create_crawler(
           'firewall_rules',
         ).crawl(
           project_id,
@@ -275,7 +276,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get GCP APP Resources
       if is_set(scan_config, 'app_services'):
-        project_result['app_services'] = CrawlerFactory.create_crawler(
+        project_result['app_services'] = await CrawlerFactory.create_crawler(
           'app_services',
         ).crawl(
           project_id,
@@ -289,7 +290,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
           storage_bucket_config = scan_config.get('storage_buckets', {})
         storage_bucket_config['gcs_output_path'] = gcs_output_path
 
-        project_result['storage_buckets'] = CrawlerFactory.create_crawler(
+        project_result['storage_buckets'] = await CrawlerFactory.create_crawler(
           'storage_buckets',
         ).crawl(
           project_id,
@@ -299,7 +300,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get DNS managed zones
       if is_set(scan_config, 'managed_zones'):
-        project_result['managed_zones'] = CrawlerFactory.create_crawler(
+        project_result['managed_zones'] = await CrawlerFactory.create_crawler(
           'managed_zones',
         ).crawl(
           project_id,
@@ -307,7 +308,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
         )
       # Get DNS policies
       if is_set(scan_config, 'dns_policies'):
-        project_result['dns_policies'] = CrawlerFactory.create_crawler(
+        project_result['dns_policies'] = await CrawlerFactory.create_crawler(
           'dns_policies',
         ).crawl(
           project_id,
@@ -325,7 +326,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get SQL instances
       if is_set(scan_config, 'sql_instances'):
-        project_result['sql_instances'] = CrawlerFactory.create_crawler(
+        project_result['sql_instances'] = await CrawlerFactory.create_crawler(
           'sql_instances',
         ).crawl(
           project_id,
@@ -334,7 +335,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get BigQuery databases and table names
       if is_set(scan_config, 'bq'):
-        project_result['bq'] = CrawlerFactory.create_crawler(
+        project_result['bq'] = await CrawlerFactory.create_crawler(
           'bq',
         ).crawl(
           project_id,
@@ -343,7 +344,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get PubSub Subscriptions
       if is_set(scan_config, 'pubsub_subs'):
-        project_result['pubsub_subs'] = CrawlerFactory.create_crawler(
+        project_result['pubsub_subs'] = await CrawlerFactory.create_crawler(
           'pubsub_subs',
         ).crawl(
           project_id,
@@ -352,7 +353,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get CloudFunctions list
       if is_set(scan_config, 'cloud_functions'):
-        project_result['cloud_functions'] = CrawlerFactory.create_crawler(
+        project_result['cloud_functions'] = await CrawlerFactory.create_crawler(
           'cloud_functions',
         ).crawl(
           project_id,
@@ -361,7 +362,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get List of BigTable Instances
       if is_set(scan_config, 'bigtable_instances'):
-        project_result['bigtable_instances'] = CrawlerFactory.create_crawler(
+        project_result['bigtable_instances'] = await CrawlerFactory.create_crawler(
           'bigtable_instances',
         ).crawl(
           project_id,
@@ -370,7 +371,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get Spanner Instances
       if is_set(scan_config, 'spanner_instances'):
-        project_result['spanner_instances'] = CrawlerFactory.create_crawler(
+        project_result['spanner_instances'] = await CrawlerFactory.create_crawler(
           'spanner_instances',
         ).crawl(
           project_id,
@@ -379,7 +380,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get FileStore Instances
       if is_set(scan_config, 'filestore_instances'):
-        project_result['filestore_instances'] = CrawlerFactory.create_crawler(
+        project_result['filestore_instances'] = await CrawlerFactory.create_crawler(
           'filestore_instances',
         ).crawl(
           project_id,
@@ -388,7 +389,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get list of KMS keys
       if is_set(scan_config, 'kms'):
-        project_result['kms'] = CrawlerFactory.create_crawler(
+        project_result['kms'] = await CrawlerFactory.create_crawler(
           'kms',
         ).crawl(
           project_id,
@@ -397,7 +398,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get information about Endpoints
       if is_set(scan_config, 'endpoints'):
-        project_result['endpoints'] = CrawlerFactory.create_crawler(
+        project_result['endpoints'] = await CrawlerFactory.create_crawler(
           'endpoints',
         ).crawl(
           project_id,
@@ -408,7 +409,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get list of API services enabled in the project
       if is_set(scan_config, 'services'):
-        project_result['services'] = CrawlerFactory.create_crawler(
+        project_result['services'] = await CrawlerFactory.create_crawler(
           'services',
         ).crawl(
           project_id,
@@ -419,7 +420,7 @@ def crawl_loop(initial_sa_tuples: List[Tuple[str, Credentials, List[str]]],
 
       # Get list of cloud source repositories enabled in the project
       if is_set(scan_config, 'sourcerepos'):
-        project_result['sourcerepos'] = CrawlerFactory.create_crawler(
+        project_result['sourcerepos'] = await CrawlerFactory.create_crawler(
           'sourcerepos',
         ).crawl(
           project_id,
@@ -586,6 +587,6 @@ def main():
     with open(args.config_path, 'r', encoding='utf-8') as f:
       scan_config = json.load(f)
 
-  crawl_loop(sa_tuples, args.output, scan_config, args.light_scan,
-             args.target_project, force_projects_list)
+  asyncio.run(crawl_loop(sa_tuples, args.output, scan_config, args.light_scan,
+             args.target_project, force_projects_list))
   return 0


### PR DESCRIPTION
## Description

This issue proposes to make the main scan loop asynchronous. This will allow the scanner to continue scanning other resources while it is waiting for the results of a long-running operation. This will improve the performance of the scanner and make it more responsive to user input.

![image](https://github.com/google/gcp_scanner/assets/77539004/c27324eb-2989-4005-8c72-8704bbf6fe59)

The scan loop would call the crawlers asynchronously.

![image](https://github.com/google/gcp_scanner/assets/77539004/cb09067f-33f2-47b3-b25b-bfc1241d436b)


## Changes 

- The main scan loop has been converted to an asynchronous function.
- The asyncio library has been used to manage the asynchronous execution of the scan loop.
- The await keyword has been used to wait for the results of long-running operations in all Crawlers, i.e., `request.execute()`

## Checklist

- [x] I have read and followed the contributing guidelines.
- [ ] I have tested my changes thoroughly and they work as expected.
- [ ] I have added necessary tests for the changes made.
- [ ] I have updated the documentation to reflect the changes made.
- [ ] My code follows the project's coding style and standards.
- [ ] I have added appropriate commit messages and comments for my changes.

## Additional Notes

I believe that the changes made to the main scan loop will improve the performance of the scanner. 

After #228, we can use the `asyncio.gather()` to achieve the similar task.