### PR TITLE
fix: Unsupported NoneType on Python older than 3.10

### DIFF
--- a/src/gcp_scanner/crawler/storage_buckets_crawler.py
+++ b/src/gcp_scanner/crawler/storage_buckets_crawler.py
@@ -14,7 +14,7 @@
 import json
 import logging
 import sys
-from typing import List, Dict, Any, Union, Tuple, TextIO
+from typing import List, Dict, Any, Union, Tuple, TextIO, Optional
 
 from googleapiclient import discovery, errors
 
@@ -105,7 +105,7 @@ class StorageBucketsCrawler(ICrawler):
     return bucket_iam_policies
 
   @classmethod
-  def _get_dump_file_dir(cls, config: Dict[str, Union[bool, str]]) -> TextIO | None:
+  def _get_dump_file_dir(cls, config: Dict[str, Union[bool, str]]) -> Optional[TextIO]:
     """Get the dump file directory based on the provided configuration.
 
     Args:


### PR DESCRIPTION
In Python3 older than 3.10 we have the following error:

TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'.

This commit fixes this issue.

Fix #238

## Description

[Provide a brief description of the changes you have made and why they are necessary.]

## Changes Made
[List the changes you have made in bullet points.]

## Checklist
- [ ] I have read and followed the contributing guidelines.
- [ ] I have tested my changes thoroughly and they work as expected.
- [ ] I have added necessary tests for the changes made.
- [ ] I have updated the documentation to reflect the changes made.
- [ ] My code follows the project's coding style and standards.
- [ ] I have added appropriate commit messages and comments for my changes.


## Related Issues
[If your changes relate to any existing issues, please list them here.]

## Additional Notes
[Provide any additional notes or context that may be helpful for the reviewers.]

Feel free to modify and customize this template as needed to fit the specific needs of the GCP Scanner project.