### PR TITLE
fix: use MANIFEST.in for controlling files in the distribution 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,8 @@
 exclude src/gcp_scanner/test_*.py
+exclude test
+exclude .idea
+exclude *.md
+exclude .github
+exclude .gitignore
+exclude Dockerfile
+exclude example_config

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+exclude src/gcp_scanner/test_*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,3 @@ Homepage = "https://github.com/google/gcp_scanner"
 
 [project.scripts]
 gcp-scanner = "gcp_scanner.scanner:main"
-
-[tool.hatch.build]
-exclude = [
-    "test",
-    ".idea",
-    "*.md",
-    "test_*.py",
-    ".github",
-    ".gitignore",
-    "Dockerfile",
-    "example_config",
-]


### PR DESCRIPTION
## Description

Get rid of using the hatch system and instead use MANIFEST.in file which is compatible with setuptools system

## Changes Made
- remove `hatch.build` section from `pyproject.toml` file
- add `MANIFEST.in` file to exclude test files


## Related Issues
#186 
