### PR TITLE
remove: `compute_client_for_credentials` func from scanner

### DIFF
--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -296,12 +296,6 @@ def iam_client_for_credentials(
   return iam_credentials.IAMCredentialsClient(credentials=credentials)
 
 
-def compute_client_for_credentials(
-  credentials: Credentials) -> discovery.Resource:
-  return discovery.build(
-    'compute', 'v1', credentials=credentials, cache_discovery=False)
-
-
 def gke_client_for_credentials(
   credentials: Credentials
 ) -> container_v1.services.cluster_manager.client.ClusterManagerClient:

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -30,7 +30,6 @@ from google.auth.exceptions import MalformedError
 from google.cloud import container_v1
 from google.cloud import iam_credentials
 from google.cloud.iam_credentials_v1.services.iam_credentials.client import IAMCredentialsClient
-from googleapiclient import discovery
 from httplib2 import Credentials
 
 from . import arguments


### PR DESCRIPTION
The function is not being used anywhere in the code-base and is redundant.

It was removed in the PR #159 and is implemented in the `src/gcp_scanner/client/compute_client.py`