### PR TITLE
Unify exception handler in storage_buckets_crawler

### DIFF
--- a/src/gcp_scanner/crawler/storage_buckets_crawler.py
+++ b/src/gcp_scanner/crawler/storage_buckets_crawler.py
@@ -47,7 +47,7 @@ class StorageBucketsCrawler(ICrawler):
     while request is not None:
       try:
         response = request.execute()
-      except errors.HttpError:
+      except Exception:
         logging.info("Failed to list buckets in the %s", project_name)
         logging.info(sys.exc_info())
         break
@@ -94,7 +94,7 @@ class StorageBucketsCrawler(ICrawler):
     request = service.buckets().getIamPolicy(bucket=bucket_name)
     try:
       response = request.execute()
-    except errors.HttpError:
+    except Exception:
       logging.info("Failed to IAM Policy in the %s", bucket_name)
       logging.info(sys.exc_info())
       return []


### PR DESCRIPTION
This PR fixes an inconsistency of exceptions handling in storage_buckets_crawler and the rest of crawlers.

In some cases, request can raise not HTTP related error which would stop GCP scanner execution.

## Description

[Provide a brief description of the changes you have made and why they are necessary.]

## Changes Made
[List the changes you have made in bullet points.]

## Checklist
- [ ] I have read and followed the contributing guidelines.
- [ ] I have tested my changes thoroughly and they work as expected.
- [ ] I have added necessary tests for the changes made.
- [ ] I have updated the documentation to reflect the changes made.
- [ ] My code follows the project's coding style and standards.
- [ ] I have added appropriate commit messages and comments for my changes.


## Related Issues
[If your changes relate to any existing issues, please list them here.]

## Additional Notes
[Provide any additional notes or context that may be helpful for the reviewers.]

Feel free to modify and customize this template as needed to fit the specific needs of the GCP Scanner project.