### PR TITLE
fix: hanging bug if output folder doesn't exist

### DIFF
--- a/src/gcp_scanner/arguments.py
+++ b/src/gcp_scanner/arguments.py
@@ -148,7 +148,10 @@ token_uri and client_secret stored in JSON format.'
  -k/--sa-key-path,-g/--gcloud-profile-path, -m, -rt, -at'
     )
   if not os.path.isdir(args.output):
-    logging.error("\"%s\" doesn't exists. Please enter a valid directory path.", args.output)
-    sys.exit(ERROR_CODES.get("InvalidDirError"))
+    logging.error(
+      '\"%s\" doesn\'t exists. Please enter a valid directory path.', 
+      args.output
+    )
+    sys.exit(ERROR_CODES.get('InvalidDirError'))
 
   return args

--- a/src/gcp_scanner/arguments.py
+++ b/src/gcp_scanner/arguments.py
@@ -149,7 +149,7 @@ token_uri and client_secret stored in JSON format.'
     )
   if not os.path.isdir(args.output):
     logging.error(
-      '\"%s\" doesn\'t exists. Please enter a valid directory path.', 
+      '\"%s\" doesn\'t exist. Please enter a valid directory path.', 
       args.output
     )
     sys.exit(ERROR_CODES.get('InvalidDirError'))

--- a/src/gcp_scanner/arguments.py
+++ b/src/gcp_scanner/arguments.py
@@ -20,6 +20,7 @@
 import argparse
 import logging
 import os
+import sys
 
 def arg_parser():
   """Creates an argument parser using the `argparse` module and defines
@@ -145,7 +146,7 @@ token_uri and client_secret stored in JSON format.'
  -k/--sa-key-path,-g/--gcloud-profile-path, -m, -rt, -at'
     )
   if not os.path.exists(args.output):
-    logging.error(f"{args.output} doesn't exists. Please enter a valid path.")
-    exit()
+    logging.error("%s doesn't exists. Please enter a valid path.", args.output)
+    sys.exit()
 
   return args

--- a/src/gcp_scanner/arguments.py
+++ b/src/gcp_scanner/arguments.py
@@ -22,6 +22,8 @@ import logging
 import os
 import sys
 
+from .error_handler import ERROR_CODES
+
 def arg_parser():
   """Creates an argument parser using the `argparse` module and defines
   several command-line arguments.
@@ -145,8 +147,8 @@ token_uri and client_secret stored in JSON format.'
         'Please select at least one option to begin scan\
  -k/--sa-key-path,-g/--gcloud-profile-path, -m, -rt, -at'
     )
-  if not os.path.exists(args.output):
-    logging.error("%s doesn't exists. Please enter a valid path.", args.output)
-    sys.exit()
+  if not os.path.isdir(args.output):
+    logging.error("\"%s\" doesn't exists. Please enter a valid directory path.", args.output)
+    sys.exit(ERROR_CODES.get("InvalidDirError"))
 
   return args

--- a/src/gcp_scanner/arguments.py
+++ b/src/gcp_scanner/arguments.py
@@ -19,6 +19,7 @@
 
 import argparse
 import logging
+import os
 
 def arg_parser():
   """Creates an argument parser using the `argparse` module and defines
@@ -143,5 +144,8 @@ token_uri and client_secret stored in JSON format.'
         'Please select at least one option to begin scan\
  -k/--sa-key-path,-g/--gcloud-profile-path, -m, -rt, -at'
     )
+  if not os.path.exists(args.output):
+    logging.error(f"{args.output} doesn't exists. Please enter a valid path.")
+    exit()
 
   return args

--- a/src/gcp_scanner/error_handler.py
+++ b/src/gcp_scanner/error_handler.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Error Handler 
+
+"""
+
+# Exit codes for Exception:
+# Error code 1 is reserved for all other kinds of errors
+# Error code 2 is reserved for command line errors
+ERROR_CODES = {
+  "InvalidDirError": 3
+}


### PR DESCRIPTION
## Description
Fixes the bug #271 where GCP Scanner freezes when there is an error in project scanning crawler.

We have solved this issue/bug by exiting the program if the output folder path is invalid. We verify the argument when it is passed by the user.

## Changes Made
- [x] arguments.py

## Checklist
- [x] I have read and followed the contributing guidelines.
- [x] I have tested my changes thoroughly and they work as expected.
- [x] I have added necessary tests for the changes made.
- [x] I have updated the documentation to reflect the changes made.
- [x] My code follows the project's coding style and standards.
- [x] I have added appropriate commit messages and comments for my changes.


## Related Issues
#271

## Additional Notes
:point_down: if the output folder path is invalid
![image](https://github.com/google/gcp_scanner/assets/77539004/22559368-f818-4208-83ab-f706345c07b1)
:point_down: if the output folder path is valid
![image](https://github.com/google/gcp_scanner/assets/77539004/603dec45-925c-4059-b435-9b6ba096145d)
