### PR TITLE
chore: Replace flask with http.server python module  for serving visualization tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ google-cloud-container==2.17.4
 google-cloud-iam==2.11.2
 httplib2==0.21.0
 requests==2.28.2
-Flask==2.3.1

--- a/src/gcp_scanner/gui/app.py
+++ b/src/gcp_scanner/gui/app.py
@@ -12,26 +12,27 @@ import os
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='GCP Scanner GUI',
-        usage='python3 %(prog)s -p 8080')
-    parser.add_argument(
-        '-p',
-        '--port',
-        default=8080,
-        type=int,
-        dest='port',
-        help='Port to serve the GUI on')
-    args = parser.parse_args()
+  parser = argparse.ArgumentParser(
+      description='GCP Scanner GUI',
+      usage='python3 %(prog)s -p 8080')
+  parser.add_argument(
+      '-p',
+      '--port',
+      default=8080,
+      type=int,
+      dest='port',
+      help='Port to serve the GUI on')
+  args = parser.parse_args()
 
-    # change directory to the GUI directory
-    os.chdir(os.path.dirname(os.path.abspath(__file__)) + '/static')
+  # change directory to the GUI directory
+  os.chdir(os.path.dirname(os.path.abspath(__file__)) + '/static')
 
-    with socketserver.TCPServer(("", args.port), http.server.SimpleHTTPRequestHandler) as httpd:
-        print('\033[92m' + 'Serving at: ' + '\033[94m' + 'http://localhost:' + str(args.port) + '\033[0m')
-
-        httpd.serve_forever()
+  handler = http.server.SimpleHTTPRequestHandler
+  with socketserver.TCPServer(('', args.port), handler) as httpd:
+    message = 'Running at: http://localhost:' + str(args.port)
+    print('\033[92m' + message + '\033[0m')
+    httpd.serve_forever()
 
 
 if __name__ == '__main__':
-    main()
+  main()

--- a/src/gcp_scanner/gui/app.py
+++ b/src/gcp_scanner/gui/app.py
@@ -1,21 +1,37 @@
 """
 The entry point for the visualization tool.
 
-This module is responsible for starting the flask server and serving the
+This module is responsible for starting the HTTP server and serving the
 static files for the GUI.
 """
 
-from flask import Flask
-from flask import send_from_directory
+import argparse
+import http.server
+import socketserver
+import os
 
-app = Flask(__name__)
-
-@app.route("/")
-def home():
-  return send_from_directory("static", "index.html")
 
 def main():
-  app.run(debug=False)
+    parser = argparse.ArgumentParser(
+        description='GCP Scanner GUI',
+        usage='python3 %(prog)s -p 8080')
+    parser.add_argument(
+        '-p',
+        '--port',
+        default=8080,
+        type=int,
+        dest='port',
+        help='Port to serve the GUI on')
+    args = parser.parse_args()
 
-if __name__ == "__main__":
-  main()
+    # change directory to the GUI directory
+    os.chdir(os.path.dirname(os.path.abspath(__file__)) + '/static')
+
+    with socketserver.TCPServer(("", args.port), http.server.SimpleHTTPRequestHandler) as httpd:
+        print('\033[92m' + 'Serving at: ' + '\033[94m' + 'http://localhost:' + str(args.port) + '\033[0m')
+
+        httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/visualization_tool/src/App.tsx
+++ b/visualization_tool/src/App.tsx
@@ -33,7 +33,7 @@ function App() {
       />
       <Routes>
         <Route
-          path="/static/"
+          path="/"
           element={
             <ResourcesPage
               resources={resources}
@@ -45,7 +45,7 @@ function App() {
           }
         />
         <Route
-          path="/static/iam-policy"
+          path="/iam-policy"
           element={
             <IAMPolicyPage
               roles={roles}
@@ -54,6 +54,8 @@ function App() {
             />
           }
         />
+
+        <Route path="*" element={<h1>404</h1>} />
       </Routes>
     </>
   );

--- a/visualization_tool/src/components/ControlMenu/ControlMenu.tsx
+++ b/visualization_tool/src/components/ControlMenu/ControlMenu.tsx
@@ -44,7 +44,7 @@ const ControlMenu = ({
           projects={projects}
           setAllowedProjects={setAllowedProjects}
         />
-        {location.pathname === '/static/' && (
+        {location.pathname === '/' && (
           <>
             <SortMenu setSortAttribute={setSortAttribute} />
             <FilterMenu setAllowedTypes={setAllowedTypes} />

--- a/visualization_tool/src/components/Navbar/Navbar.tsx
+++ b/visualization_tool/src/components/Navbar/Navbar.tsx
@@ -41,8 +41,8 @@ const Navbar = ({searchQuery, setSearchQuery}: NavbarProps) => {
       <div className="pages-nav">
         <div className="links">
           <Link
-            to="/static/"
-            className={location.pathname === '/static/' ? 'active' : ''}
+            to="/"
+            className={location.pathname === '/' ? 'active' : ''}
             onClick={() => {
               setSearchQuery('');
             }}
@@ -50,10 +50,8 @@ const Navbar = ({searchQuery, setSearchQuery}: NavbarProps) => {
             Resources
           </Link>
           <Link
-            to="/static/iam-policy"
-            className={
-              location.pathname === '/static/iam-policy' ? 'active' : ''
-            }
+            to="/iam-policy"
+            className={location.pathname === '/iam-policy' ? 'active' : ''}
             onClick={() => {
               setSearchQuery('');
             }}
@@ -68,9 +66,7 @@ const Navbar = ({searchQuery, setSearchQuery}: NavbarProps) => {
               name="search-input"
               id="search-input"
               placeholder={
-                location.pathname === '/static/iam-policy'
-                  ? 'Email'
-                  : 'Resources Name'
+                location.pathname === '/iam-policy' ? 'Email' : 'Resources Name'
               }
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}

--- a/visualization_tool/src/components/ResourcesList/utils.ts
+++ b/visualization_tool/src/components/ResourcesList/utils.ts
@@ -17,7 +17,7 @@ const typeToImage = (resource: Resource) => {
       return ComputeDisk;
     case 'Managed Zone':
       return ManagedZone;
-    case 'SQL Instance':
+    case 'Sql Instance':
       return SQLInstance;
     case 'Cloud Function':
       return CloudFunction;

--- a/visualization_tool/src/main.tsx
+++ b/visualization_tool/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
+import App from './App';
 import './index.css';
 import {BrowserRouter} from 'react-router-dom';
 

--- a/visualization_tool/tsconfig.json
+++ b/visualization_tool/tsconfig.json
@@ -7,8 +7,8 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/visualization_tool/vite.config.ts
+++ b/visualization_tool/vite.config.ts
@@ -1,11 +1,10 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "/static/",
   build: {
-    outDir: "../src/gcp_scanner/gui/static",
+    outDir: '../src/gcp_scanner/gui/static',
   },
 });


### PR DESCRIPTION
## Description

Instead of adding `flask` to the project dependencies to create the server that hosts the tool, use the already existing Python `http.server` module for creating the server

## Changes Made
- Change implementationon of `gui/app.py`
- Fix some errors related to building the visualization tool
- Remove `static` word from tool URLs

## Additional Notes
The following steps to build the tool and test it after the build
1. `cd visualization_tool/`
2. `npm run build`
3. `cd  cd ../src/gcp_scanner/gui/`
4. `python app.py`