### PR TITLE
fix: Handle of missing iam_policy key in input JSON

### DIFF
--- a/visualization_tool/src/components/ResourcesList/ResourcesList.tsx
+++ b/visualization_tool/src/components/ResourcesList/ResourcesList.tsx
@@ -43,7 +43,10 @@ const ResourcesList = ({
       <div className="resources-list__table">
         {filteredResources.map(resource => {
           return (
-            <div className="resources-list__table__card" key={resource.id}>
+            <div
+              className="resources-list__table__card"
+              key={resource.id ? resource.id : resource.name}
+            >
               <p className="resource-name">{resource.name}</p>
               <div className="resource-type_container">
                 <img src={typeToImage(resource)} className="resources-image" />

--- a/visualization_tool/src/parser/parser.ts
+++ b/visualization_tool/src/parser/parser.ts
@@ -65,23 +65,24 @@ const parseResources = (data: OutputFile, fileName: string) => {
 
 const parseIAMRoles = (data: OutputFile, fileName: string) => {
   const roles: IAMRole[] = [];
+
+  if (!data.iam_policy) return roles;
+
   const projectId = data.project_info.projectId;
   const currentRoles = data.iam_policy as IMAPolicyField[];
 
-  if (roles instanceof Array) {
-    for (const role of currentRoles) {
-      roles.push({
-        file: fileName,
-        projectId,
-        role: `${role.role.split('/')[1]}`,
-        members: role.members.map(member => {
-          return {
-            memberType: member.split(':')[0],
-            email: member.split(':')[1],
-          };
-        }),
-      });
-    }
+  for (const role of currentRoles) {
+    roles.push({
+      file: fileName,
+      projectId,
+      role: `${role.role.split('/')[1]}`,
+      members: role.members.map(member => {
+        return {
+          memberType: member.split(':')[0],
+          email: member.split(':')[1],
+        };
+      }),
+    });
   }
 
   return roles;

--- a/visualization_tool/src/types/resources.ts
+++ b/visualization_tool/src/types/resources.ts
@@ -44,7 +44,7 @@ type ProjectInfo = {
 
 type OutputFile = {
   project_info: ProjectInfo;
-  iam_policy: IMAPolicyField[];
+  iam_policy?: IMAPolicyField[];
 };
 
 export type {ResourceType, ResourceStatus, Resource, OutputFile};


### PR DESCRIPTION
## Description

Fix error `Invalid file` related to missing `iam_policy` key from the output of the GCP Scanner 

## Changes Made
- Make the `iam_policy` field optional in the `OutputFile` type
- Edit the parser to check if the `iam_policy` field exists or not
- Add a fallback value to the `key` property in the `ResourcesList` 
