### PR TITLE
Use extend on crawlers to avoid replacing results

### DIFF
--- a/src/gcp_scanner/crawler/app_services_crawler.py
+++ b/src/gcp_scanner/crawler/app_services_crawler.py
@@ -52,7 +52,7 @@ class AppServicesCrawler(ICrawler):
       app_services["services"] = list()
       while request is not None:
         response = request.execute()
-        app_services["services"] = response.get("services", [])
+        app_services["services"].extend(response.get("services", []))
         request = service.apps().services().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/bigquery_crawler.py
+++ b/src/gcp_scanner/crawler/bigquery_crawler.py
@@ -75,7 +75,7 @@ class BigQueryCrawler(ICrawler):
         projectId=project_id, datasetId=dataset_id)
       while request is not None:
         response = request.execute()
-        list_of_tables = response.get("tables", [])
+        list_of_tables.extend(response.get("tables", []))
         request = bq_service.tables().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/bigtable_instances_crawler.py
+++ b/src/gcp_scanner/crawler/bigtable_instances_crawler.py
@@ -44,7 +44,7 @@ class BigTableInstancesCrawler(ICrawler):
         parent=f"projects/{project_id}")
       while request is not None:
         response = request.execute()
-        bigtable_instances_list = response.get("instances", [])
+        bigtable_instances_list.extend(response.get("instances", []))
         request = service.projects().instances().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/cloud_functions_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_functions_crawler.py
@@ -44,7 +44,7 @@ class CloudFunctionsCrawler(ICrawler):
         parent=f"projects/{project_id}/locations/-")
       while request is not None:
         response = request.execute()
-        functions_list = response.get("functions", [])
+        functions_list.extend(response.get("functions", []))
         request = service.projects().locations().functions().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/cloud_resource_manager_project_list_crawler.py
+++ b/src/gcp_scanner/crawler/cloud_resource_manager_project_list_crawler.py
@@ -40,7 +40,7 @@ class CloudResourceManagerProjectListCrawler(ICrawler):
       request = service.projects().list()
       while request is not None:
         response = request.execute()
-        project_list = response.get("projects",[])
+        project_list.extend(response.get("projects",[]))
         request = service.projects().list_next(
             previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/compute_disks_crawler.py
+++ b/src/gcp_scanner/crawler/compute_disks_crawler.py
@@ -42,10 +42,10 @@ class ComputeDisksCrawler(ICrawler):
       while request is not None:
         response = request.execute()
         if response.get("items", None) is not None:
-          disk_names_list = [
+          disk_names_list.extend([
             disk for _, disks_scoped_list in response["items"].items()
             for disk in disks_scoped_list.get("disks", [])
-          ]
+          ])
         request = service.disks().aggregatedList_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/compute_firewall_rules_crawler.py
+++ b/src/gcp_scanner/crawler/compute_firewall_rules_crawler.py
@@ -41,8 +41,8 @@ class ComputeFirewallRulesCrawler(ICrawler):
       request = service.firewalls().list(project=project_name)
       while request is not None:
         response = request.execute()
-        firewall_rules_list = [(firewall["name"],)
-                               for firewall in response.get("items", [])]
+        firewall_rules_list.extend([(firewall["name"],)
+                               for firewall in response.get("items", [])])
         request = service.firewalls().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/compute_images_crawler.py
+++ b/src/gcp_scanner/crawler/compute_images_crawler.py
@@ -42,7 +42,7 @@ class ComputeImagesCrawler(ICrawler):
       request = service.images().list(project=project_name)
       while request is not None:
         response = request.execute()
-        images_result = response.get("items", [])
+        images_result.extend(response.get("items", []))
         request = service.images().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/compute_instances_crawler.py
+++ b/src/gcp_scanner/crawler/compute_instances_crawler.py
@@ -42,9 +42,9 @@ class ComputeInstancesCrawler(ICrawler):
       while request is not None:
         response = request.execute()
         if response.get("items", None) is not None:
-          images_result = [instance
+          images_result.extend([instance
                            for _, instances_scoped_list in response["items"].items()
-                           for instance in instances_scoped_list.get("instances", [])]
+                           for instance in instances_scoped_list.get("instances", [])])
         request = service.instances().aggregatedList_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/compute_snapshots_crawler.py
+++ b/src/gcp_scanner/crawler/compute_snapshots_crawler.py
@@ -43,7 +43,7 @@ class ComputeSnapshotsCrawler(ICrawler):
       request = service.snapshots().list(project=project_name)
       while request is not None:
         response = request.execute()
-        snapshots_list = response.get("items", [])
+        snapshots_list.extend(response.get("items", []))
         request = service.snapshots().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/compute_static_ips_crawler.py
+++ b/src/gcp_scanner/crawler/compute_static_ips_crawler.py
@@ -42,9 +42,9 @@ class ComputeStaticIPsCrawler(ICrawler):
       request = service.addresses().aggregatedList(project=project_name)
       while request is not None:
         response = request.execute()
-        ips_list = [{name: addresses_scoped_list}
+        ips_list.extend([{name: addresses_scoped_list}
                     for name, addresses_scoped_list in response["items"].items()
-                    if addresses_scoped_list.get("addresses", None) is not None]
+                    if addresses_scoped_list.get("addresses", None) is not None])
         request = service.addresses().aggregatedList_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/compute_subnets_crawler.py
+++ b/src/gcp_scanner/crawler/compute_subnets_crawler.py
@@ -42,7 +42,7 @@ class ComputeSubnetsCrawler(ICrawler):
       while request is not None:
         response = request.execute()
         if response.get("items", None) is not None:
-          subnets_list = list(response["items"].items())
+          subnets_list.extend(list(response["items"].items()))
         request = service.subnetworks().aggregatedList_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
+++ b/src/gcp_scanner/crawler/dns_managed_zones_crawler.py
@@ -42,7 +42,7 @@ class DNSManagedZonesCrawler(ICrawler):
       request = service.managedZones().list(project=project_name)
       while request is not None:
         response = request.execute()
-        zones_list = response.get("managedZones", [])
+        zones_list.extend(response.get("managedZones", []))
         request = service.managedZones().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/endpoints_crawler.py
+++ b/src/gcp_scanner/crawler/endpoints_crawler.py
@@ -41,7 +41,7 @@ class EndpointsCrawler(ICrawler):
       request = service.services().list(producerProjectId=project_name)
       while request is not None:
         response = request.execute()
-        endpoints_list = response.get("services", [])
+        endpoints_list.extend(response.get("services", []))
         request = service.services().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/filestore_instances_crawler.py
+++ b/src/gcp_scanner/crawler/filestore_instances_crawler.py
@@ -44,7 +44,7 @@ class FilestoreInstancesCrawler(ICrawler):
         parent=f"projects/{project_id}/locations/-")
       while request is not None:
         response = request.execute()
-        filestore_instances_list = response.get("instances", [])
+        filestore_instances_list.extend(response.get("instances", []))
         request = service.projects().locations().instances().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/machine_images_crawler.py
+++ b/src/gcp_scanner/crawler/machine_images_crawler.py
@@ -41,7 +41,7 @@ class ComputeMachineImagesCrawler(ICrawler):
       request = service.machineImages().list(project=project_name)
       while request is not None:
         response = request.execute()
-        machine_images_list = response.get("items", [])
+        machine_images_list.extend(response.get("items", []))
         request = service.machineImages().list_next(
           previous_request=request, previous_response=response
         )

--- a/src/gcp_scanner/crawler/pubsub_subscriptions_crawler.py
+++ b/src/gcp_scanner/crawler/pubsub_subscriptions_crawler.py
@@ -45,7 +45,7 @@ class PubSubSubscriptionsCrawler(ICrawler):
         project=f"projects/{project_id}")
       while request is not None:
         response = request.execute()
-        pubsubs_list = response.get("subscriptions", [])
+        pubsubs_list.extend(response.get("subscriptions", []))
         request = service.projects().subscriptions().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/service_accounts_crawler.py
+++ b/src/gcp_scanner/crawler/service_accounts_crawler.py
@@ -44,9 +44,9 @@ class ServiceAccountsCrawler(ICrawler):
       request = service.projects().serviceAccounts().list(name=name)
       while request is not None:
         response = request.execute()
-        service_accounts = [(service_account["email"],
+        service_accounts.extend([(service_account["email"],
                              service_account.get("description", ""))
-                            for service_account in response.get("accounts", [])]
+                            for service_account in response.get("accounts", [])])
 
         request = service.projects().serviceAccounts().list_next(
           previous_request=request, previous_response=response)

--- a/src/gcp_scanner/crawler/spanner_instances_crawler.py
+++ b/src/gcp_scanner/crawler/spanner_instances_crawler.py
@@ -44,7 +44,7 @@ class SpannerInstancesCrawler(ICrawler):
         parent=f"projects/{project_id}")
       while request is not None:
         response = request.execute()
-        spanner_instances_list = response.get("instances", [])
+        spanner_instances_list.extend(response.get("instances", []))
         request = service.projects().instances().list_next(
           previous_request=request, previous_response=response)
     except Exception:

--- a/src/gcp_scanner/crawler/sql_instances_crawler.py
+++ b/src/gcp_scanner/crawler/sql_instances_crawler.py
@@ -43,7 +43,7 @@ class SQLInstancesCrawler(ICrawler):
       request = service.instances().list(project=project_name)
       while request is not None:
         response = request.execute()
-        sql_instances_list = response.get("items", [])
+        sql_instances_list.extend(response.get("items", []))
         request = service.instances().list_next(
           previous_request=request, previous_response=response)
     except Exception:


### PR DESCRIPTION
We had a bug in most of our crawlers when data would be replaced instead of appended to results list.

Fixes #254 