### PR TITLE
Optimize GitHub Actions Workflow: Cache Dependencies install and Parallelize Linting & Testing

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,13 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,8 +38,12 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with pylint
       run: |
+        # stop the build if there are Python syntax errors or undefined names
+        #flake8 . --count --select=E9,F63,F7,F82 --ignore=E111 --show-source --statistics
         wget https://google.github.io/styleguide/pylintrc
         pylint --rcfile pylintrc --disable=W0703,R1734,R1735,C0209,C0103,R1732 src/gcp_scanner/*.py
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
   test:
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -59,6 +59,7 @@ jobs:
       with:
         path: |
           ~/.cache/pip
+          **/__pycache__
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         enableCrossOsArchive: true
     - name: Install dependencies

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: GCP Scanner tests
+name: GCP Scanner linting and testing
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
 
     runs-on: self-hosted
 
@@ -24,25 +24,46 @@ jobs:
       with:
         python-version: "3.10"
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v2
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        path: |
+          ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint pytest
+        pip install pylint
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with pylint
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        #flake8 . --count --select=E9,F63,F7,F82 --ignore=E111 --show-source --statistics
         wget https://google.github.io/styleguide/pylintrc
         pylint --rcfile pylintrc --disable=W0703,R1734,R1735,C0209,C0103,R1732 src/gcp_scanner/*.py
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  test:
+
+    runs-on: self-hosted
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,11 +38,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with pylint
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,13 +24,12 @@ jobs:
       with:
         python-version: "3.10"
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        enableCrossOsArchive: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -56,13 +55,12 @@ jobs:
       with:
         python-version: "3.10"
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        enableCrossOsArchive: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,12 +24,20 @@ jobs:
       with:
         python-version: "3.10"
     - name: Cache dependencies
+      id: cache
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pip
+          **/__pycache__
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         enableCrossOsArchive: true
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true' 
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -55,6 +63,7 @@ jobs:
       with:
         python-version: "3.10"
     - name: Cache dependencies
+      id: cache
       uses: actions/cache@v3
       with:
         path: |
@@ -63,6 +72,7 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         enableCrossOsArchive: true
     - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true' 
       run: |
         python -m pip install --upgrade pip
         pip install pytest


### PR DESCRIPTION
## Description

This pull request addresses the previous slow execution time of our GitHub Actions workflow which was averaging around 2 minutes and 30 seconds. By caching dependencies and parallelizing the linting and testing jobs, this PR aims to significantly reduce the workflow execution time, thus speeding up our CI/CD pipeline.

## Changes Made
- Added a step to cache Python dependencies using the `actions/cache` action.
- Split the 'Lint with pylint' and 'Test with pytest' steps into separate parallel jobs to allow for faster execution.

## Additional Notes
- These changes are expected to provide a notable improvement in the workflow execution time, making our development process more efficient.

