### PR TITLE
Refinement: Removed Redundancy of Scan Config Passing

### DIFF
--- a/src/gcp_scanner/crawler/interface_crawler.py
+++ b/src/gcp_scanner/crawler/interface_crawler.py
@@ -26,6 +26,12 @@ class ICrawler(metaclass=ABCMeta):
 
   """
 
+  """Variable to identify if config file is needed
+
+  Access Type: Private
+  """
+  _config_depndency = False
+
   @staticmethod
   @abstractmethod
   def crawl(project_name: str, service: discovery.Resource,
@@ -49,3 +55,12 @@ class ICrawler(metaclass=ABCMeta):
     """
 
     raise NotImplementedError("Child class must implement the crawl() method.")
+  
+  @property
+  def crawler_config(self) -> bool:
+    """Checks if the class needs a config file
+
+    Returns:
+        bool: Returns config_depndency private variable which is False by default.
+    """
+    return self._config_depndency

--- a/src/gcp_scanner/crawler/interface_crawler.py
+++ b/src/gcp_scanner/crawler/interface_crawler.py
@@ -30,7 +30,7 @@ class ICrawler(metaclass=ABCMeta):
 
   Access Type: Private
   """
-  _config_depndency = False
+  _config_dependency = False
 
   @staticmethod
   @abstractmethod
@@ -61,6 +61,6 @@ class ICrawler(metaclass=ABCMeta):
     """Checks if the class needs a config file
 
     Returns:
-        bool: Returns config_depndency private variable which is False by default.
+        bool: Returns config_dependency private variable which is False by default.
     """
-    return self._config_depndency
+    return self._config_dependency

--- a/src/gcp_scanner/crawler/interface_crawler.py
+++ b/src/gcp_scanner/crawler/interface_crawler.py
@@ -57,7 +57,7 @@ class ICrawler(metaclass=ABCMeta):
     raise NotImplementedError("Child class must implement the crawl() method.")
   
   @property
-  def crawler_config(self) -> bool:
+  def has_config_dependency(self) -> bool:
     """Checks if the class needs a config file
 
     Returns:

--- a/src/gcp_scanner/crawler/storage_buckets_crawler.py
+++ b/src/gcp_scanner/crawler/storage_buckets_crawler.py
@@ -81,7 +81,7 @@ class StorageBucketsCrawler(ICrawler):
     return buckets_dict
   
   @property
-  def crawler_config(self) -> bool:
+  def has_config_dependency(self) -> bool:
     """Checks if the class needs a config file
 
     Returns:

--- a/src/gcp_scanner/crawler/storage_buckets_crawler.py
+++ b/src/gcp_scanner/crawler/storage_buckets_crawler.py
@@ -24,7 +24,7 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class StorageBucketsCrawler(ICrawler):
   """Handle crawling of bucket names data."""
 
-  _config_depndency = True # Private Variable Denoting Config Files Needed
+  _config_dependency = True # Define that config file is needed
 
   def crawl(self, project_name: str, service: discovery.Resource,
             config: Dict[str, Union[bool, str]] = None) -> Dict[str, Tuple[Any, List[Any]]]:
@@ -85,9 +85,9 @@ class StorageBucketsCrawler(ICrawler):
     """Checks if the class needs a config file
 
     Returns:
-        bool: Returns config_depndency private variable which is False by default.
+        bool: Returns config_dependency private variable which is False by default.
     """
-    return self._config_depndency
+    return self._config_dependency
 
   @classmethod
   def _get_bucket_iam(cls, bucket_name: str, service: discovery.Resource) -> List[Any]:

--- a/src/gcp_scanner/crawler/storage_buckets_crawler.py
+++ b/src/gcp_scanner/crawler/storage_buckets_crawler.py
@@ -24,6 +24,8 @@ from gcp_scanner.crawler.interface_crawler import ICrawler
 class StorageBucketsCrawler(ICrawler):
   """Handle crawling of bucket names data."""
 
+  _config_depndency = True # Private Variable Denoting Config Files Needed
+
   def crawl(self, project_name: str, service: discovery.Resource,
             config: Dict[str, Union[bool, str]] = None) -> Dict[str, Tuple[Any, List[Any]]]:
     """Retrieve a list of buckets available in the project.
@@ -77,6 +79,15 @@ class StorageBucketsCrawler(ICrawler):
     if dump_fd is not None:
       dump_fd.close()
     return buckets_dict
+  
+  @property
+  def crawler_config(self) -> bool:
+    """Checks if the class needs a config file
+
+    Returns:
+        bool: Returns config_depndency private variable which is False by default.
+    """
+    return self._config_depndency
 
   @classmethod
   def _get_bucket_iam(cls, bucket_name: str, service: discovery.Resource) -> List[Any]:

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -180,8 +180,10 @@ def get_crawl(
   Returns:
     scan_result: a dictionary with scanning results
   """
-
-  res = crawler.crawl(project_id, client, crawler_config)
+  if crawler.crawler_config:
+    res = crawler.crawl(project_id, client, crawler_config)
+  else:
+    res = crawler.crawl(project_id, client)
   if res is not None and len(res) != 0:
     scan_results[crawler_name] = res
   return scan_results

--- a/src/gcp_scanner/scanner.py
+++ b/src/gcp_scanner/scanner.py
@@ -180,7 +180,7 @@ def get_crawl(
   Returns:
     scan_result: a dictionary with scanning results
   """
-  if crawler.crawler_config:
+  if crawler.has_config_dependency:
     res = crawler.crawl(project_id, client, crawler_config)
   else:
     res = crawler.crawl(project_id, client)


### PR DESCRIPTION
## Description

- Issue: https://github.com/google/gcp_scanner/issues/241. Hence I created a property `crawler_config` in base class `ICrawler` which is returns bool value, where `default=False`
- If there is a need or optionality of passing the config to the crawler then this property `crawler_config` in the base class needs to be overridden in the sub class to return True.

**Note** : Currently as I was checking all the crawlers, I have just seen that config is being used only inside the `StorageBucketsCrawler` crawler. So only its value is set as True in its base class.

## Changes Made

- Base class `ICrawler` has a new property called as `crawler_config` which returns the abstracted private variable `_config_depndency` which is set to **False** by default.
- `StorageBucketsCrawler` class has overridden  `crawler_config` to return True.
- `get_crawl` function in scanner.py has a check now calling the `crawler_config` to decide to send config or not.

## Testing

Local testing done with logs denoting that where config file is sent and where it is not. (**Removed the logs after the testing)**

![Screenshot 2023-11-23 at 6 01 29 PM](https://github.com/google/gcp_scanner/assets/79361941/24bf44ff-72f7-423e-b915-b473d884aa27)

This check denotes that only `StorageBucketsCrawler` is being sent the config file