### PR TITLE
feat : Add functionality in test file to store crawler results

### DIFF
--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -109,7 +109,7 @@ def print_diff(f1, f2):
 def save_to_test_file(res, resource_type=None):
   res = json.dumps(res, indent=2, sort_keys=False)
 
-  if not resource_type:
+  if resource_type is None:
     with open(f"test_res", "w", encoding="utf-8") as outfile:
       outfile.write(res)
   else:
@@ -142,7 +142,7 @@ def compare_volatile(f1, f2):
 
 
 def verify(res_to_verify, resource_type, volatile=True, store_results=False):
-  if not store_results:
+  if store_results is False:
     save_to_test_file(res_to_verify)
   else:
     save_to_test_file(res_to_verify, resource_type)

--- a/src/gcp_scanner/test_unit.py
+++ b/src/gcp_scanner/test_unit.py
@@ -106,10 +106,15 @@ def print_diff(f1, f2):
     res += line
 
 
-def save_to_test_file(res):
+def save_to_test_file(res, resource_type=None):
   res = json.dumps(res, indent=2, sort_keys=False)
-  with open("test_res", "w", encoding="utf-8") as outfile:
-    outfile.write(res)
+
+  if not resource_type:
+    with open(f"test_res", "w", encoding="utf-8") as outfile:
+      outfile.write(res)
+  else:
+    with open(f"test_res_{resource_type}", "w", encoding="utf-8") as outfile:
+      outfile.write(res)
 
 
 def compare_volatile(f1, f2):
@@ -136,8 +141,11 @@ def compare_volatile(f1, f2):
   return res
 
 
-def verify(res_to_verify, resource_type, volatile=True):
-  save_to_test_file(res_to_verify)
+def verify(res_to_verify, resource_type, volatile=True, store_results=False):
+  if not store_results:
+    save_to_test_file(res_to_verify)
+  else:
+    save_to_test_file(res_to_verify, resource_type)
   f1 = "test_res"
   f2 = f"test/{resource_type}"
 
@@ -387,6 +395,7 @@ class TestCrawler(unittest.TestCase):
           ClientFactory.get_client("compute").get_service(self.credentials),
         ),
         "compute_instances",
+        True,
         True,
       )
     )
@@ -716,7 +725,8 @@ class TestCrawler(unittest.TestCase):
           ),
         ),
         "services",
-        True
+        True,
+        True,
       )
     )
 


### PR DESCRIPTION
## Description

In the current approach, the test_res file is over written while testing all the crawlers. While this is an efficient approach, it becomes hard to debug at times when the tests fail as developer does not have access to the test_res file which is compared with the sample output. 

This PR adds an additional parameter in verify function called store_results. If this parameter is set to True by developer during function call, it stores the result of the test crawler, which can be useful to analyze if test results fail. 

Below is an example of how the new verify function can be called. 
```
def test_compute_instance_name(self):
    """Test compute instance name."""
    self.assertTrue(
      verify(
        CrawlerFactory.create_crawler(
          "compute_instances",
        ).crawl(
          PROJECT_NAME,
          ClientFactory.get_client("compute").get_service(self.credentials),
        ),
        "compute_instances",
        True,
        True,
      )
    )
```

NOTE : In this PR, store_results has been set to True for 2 resources - compute_instances and services