### PR TITLE
Add feature to detect GCP SAs with DWD permissions #306

### DIFF
--- a/dwd_sa_details.txt
+++ b/dwd_sa_details.txt
@@ -1,0 +1,16 @@
+# GCP Service Account DWD Detector
+
+This repository contains a script for detecting Google Cloud Platform (GCP) Service Accounts (SA) with Domain-Wide Delegation (DWD) permissions.
+
+## Changes Made
+
+- Added a Python script `dwd_sa_detector.py` that checks for DWD permissions in GCP SAs and flags any that are found. This script uses the `google-auth` and `google-auth-httplib2` libraries to authenticate and create a service client. It then lists all the service accounts in the project and checks if they have the `roles/iam.serviceAccountTokenCreator` role, which is one of the roles that enables DWD.
+
+- The script logs the details of the service accounts with DWD permissions into a file named `dwd_sa_details.txt`. This could be useful for auditing or further analysis.
+
+## Installation
+
+You need to install the necessary libraries using pip:
+
+```bash
+pip install --upgrade google-auth google-auth-httplib2 google-auth-oauthlib google-api-python-client

--- a/dwd_sa_detector.py
+++ b/dwd_sa_detector.py
@@ -1,0 +1,29 @@
+import google.auth
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+import googleapiclient.discovery
+
+# Load the credentials
+credentials, project = google.auth.default()
+
+# Build the service
+service = googleapiclient.discovery.build('iam', 'v1', credentials=credentials)
+
+# Get the project's service accounts
+service_accounts = service.projects().serviceAccounts().list(
+    name='projects/YOUR_PROJECT_ID').execute()
+
+# Open a file to log the details
+with open('dwd_sa_details.txt', 'w') as f:
+    # Iterate over the service accounts
+    for account in service_accounts['accounts']:
+        # Get the IAM policy for the service account
+        policy = service.projects().serviceAccounts().getIamPolicy(
+            resource=account['name']).execute()
+
+        # Check if the service account has the DWD role
+        for binding in policy.get('bindings', []):
+            if 'roles/iam.serviceAccountTokenCreator' in binding['role']:
+                # Log the details into the file
+                f.write(f"Service account {account['email']} has DWD permissions.\n")


### PR DESCRIPTION
# GCP Service Account DWD Detector

This repository contains a script for detecting Google Cloud Platform (GCP) Service Accounts (SA) with Domain-Wide Delegation (DWD) permissions.

## Changes Made

- Added a Python script `dwd_sa_detector.py` that checks for DWD permissions in GCP SAs and flags any that are found. This script uses the `google-auth` and `google-auth-httplib2` libraries to authenticate and create a service client. It then lists all the service accounts in the project and checks if they have the `roles/iam.serviceAccountTokenCreator` role, which is one of the roles that enables DWD.

- The script logs the details of the service accounts with DWD permissions into a file named `dwd_sa_details.txt`. This could be useful for auditing or further analysis.

## Installation

You need to install the necessary libraries using pip:

```bash
pip install --upgrade google-auth google-auth-httplib2 google-auth-oauthlib google-api-python-client
