### PR TITLE
Fix broken link to docs page

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,5 +1,5 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# For more information see: https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python
 
 name: GCP Scanner linting and testing
 


### PR DESCRIPTION
## Description

In one of the GitHub action there was a link present for documentation on using python with GitHub Actions but the link was redirecting to support page.

I found another similar documentation on docs page of GitHub Actions and this PR updates that link.

## Changes Made
[List the changes you have made in bullet points.]

- Updated the docs link in GitHub action `python-app.yml`

## Checklist
- [ ] I have read and followed the contributing guidelines.
- [ ] I have tested my changes thoroughly and they work as expected.
- [ ] I have added necessary tests for the changes made.
- [ ] I have updated the documentation to reflect the changes made.
- [ ] My code follows the project's coding style and standards.
- [ ] I have added appropriate commit messages and comments for my changes.


## Related Issues
[If your changes relate to any existing issues, please list them here.]

## Additional Notes
[Provide any additional notes or context that may be helpful for the reviewers.]

Feel free to modify and customize this template as needed to fit the specific needs of the GCP Scanner project.